### PR TITLE
Ensure research folder state is set to secured after vault package is secured

### DIFF
--- a/folder.py
+++ b/folder.py
@@ -201,7 +201,7 @@ def folder_secure(ctx, coll):
 
         # Create vault target and set status to INCOMPLETE.
         msi.coll_create(ctx, target, '', irods_types.BytesBuf())
-        avu.set_on_coll(ctx, dest_path, constants.IIVAULTSTATUSATTRNAME, constants.vault_package_state.INCOMPLETE)
+        avu.set_on_coll(ctx, target, constants.IIVAULTSTATUSATTRNAME, constants.vault_package_state.INCOMPLETE)
 
     # Try to register EPIC PID
     ret = epic.register_epic_pid(ctx, target)

--- a/folder.py
+++ b/folder.py
@@ -192,11 +192,16 @@ def folder_secure(ctx, coll):
             log.write(ctx, "Could not set acl (admin:null) for collection: " + coll)
             return '1'
 
+    # Determine vault target if it does not exist.
     if not found:
         target = determine_vault_target(ctx, coll)
         if target == "":
             log.write(ctx, "folder_secure: No vault target found")
             return '1'
+
+        # Create vault target and set status to INCOMPLETE.
+        msi.coll_create(ctx, target, '', irods_types.BytesBuf())
+        avu.set_on_coll(ctx, dest_path, constants.IIVAULTSTATUSATTRNAME, constants.vault_package_state.INCOMPLETE)
 
     # Try to register EPIC PID
     ret = epic.register_epic_pid(ctx, target)
@@ -322,7 +327,7 @@ def determine_vault_target(ctx, folder):
 
     vault_group_name = constants.IIVAULTPREFIX + base_name
 
-    # Create target and ensure it does not exist already
+    # Ensure vault target does not exist.
     i = 0
     target_base = "/" + user.zone(ctx) + "/home/" + vault_group_name + "/" + datapackage_name + "[" + timestamp + "]"
     target = target_base

--- a/folder.py
+++ b/folder.py
@@ -139,8 +139,6 @@ def rule_folder_secure(ctx, coll):
 
     :return: '0' when nu error occurred
     """
-    log.write(ctx, 'Starting folder secure - ' + coll)
-
     return folder_secure(ctx, coll)
 
 
@@ -153,8 +151,10 @@ def folder_secure(ctx, coll):
 
     :return: '0' when nu error occurred
     """
+    log.write(ctx, 'folder_secure: Start securing folder <{}>'.format(coll))
+
     if user.user_type(ctx) != 'rodsadmin':
-        log.write(ctx, "User is no rodsadmin")
+        log.write(ctx, "folder_secure: User is no rodsadmin")
         return '1'
 
     # Check modify access on research folder.
@@ -195,7 +195,7 @@ def folder_secure(ctx, coll):
     if not found:
         target = determine_vault_target(ctx, coll)
         if target == "":
-            log.write(ctx, "No vault target found")
+            log.write(ctx, "folder_secure: No vault target found")
             return '1'
 
     # Try to register EPIC PID
@@ -205,8 +205,8 @@ def folder_secure(ctx, coll):
     http_code = ret['httpCode']
 
     if (http_code != "0" and http_code != "200" and http_code != "201"):
-        # Always retry
-        log.write(ctx, "folder_secure:  returned httpCode: " + http_code)
+        # Something went wrong while registering EPIC PID, set cronjob state to retry.
+        log.write(ctx, "folder_secure: epid pid returned http <{}>".format(http_code))
         if modify_access != b'\x01':
             try:
                 msi.set_acl(ctx, "default", "admin:write", user.full_name(ctx), coll)
@@ -233,62 +233,22 @@ def folder_secure(ctx, coll):
         # save EPIC Persistent ID in metadata
         epic.save_epic_pid(ctx, target, url, pid)
 
-    # Set research folder status.
-    try:
-        msi.set_acl(ctx, "recursive", "admin:write", user.full_name(ctx), coll)
-    except msi.Error as e:
-        log.write(ctx, "Could not set acl (admin:write) for collection: " + coll)
-        return '1'
-
-    parent, chopped_coll = pathutil.chop(coll)
-
-    while parent != "/" + user.zone(ctx) + "/home":
-        log.write(ctx, parent)
-        try:
-            msi.set_acl(ctx, "default", "admin:write", user.full_name(ctx), parent)
-            log.write(ctx, "SET ACL (admin:write) on " + parent)
-        except msi.Error as e:
-            log.write(ctx, "Could not set ACL on " + parent)
-        parent, chopped_coll = pathutil.chop(parent)
-
-    avu.set_on_coll(ctx, coll, constants.IISTATUSATTRNAME, constants.research_package_state.SECURED)
-
-    try:
-        msi.set_acl(ctx, "recursive", "admin:null", user.full_name(ctx), coll)
-    except msi.Error as e:
-        log.write(ctx, "Could not set acl (admin:null) for collection: " + coll)
-        return '1'
-
-    parent, chopped_coll = pathutil.chop(coll)
-    while parent != "/" + user.zone(ctx) + "/home":
-        try:
-            msi.set_acl(ctx, "default", "admin:null", user.full_name(ctx), parent)
-        except msi.Error as e:
-            log.write(ctx, "Could not set ACL (admin:null) on " + parent)
-
-        parent, chopped_coll = pathutil.chop(parent)
-
-    # Copy provenance log.
+    # Copy provenance log from research folder to vault package.
     provenance.provenance_copy_log(ctx, coll, target)
 
     # Set vault permissions for new vault package.
     group = collection_group_name(ctx, coll)
     if group == '':
-        log.write(ctx, "Cannot determine which research group " + coll + " belongs to")
+        log.write(ctx, "folder_secure: Cannot determine which research group <{}> belongs to".format(coll))
         return '1'
 
     vault.set_vault_permissions(ctx, group, coll, target)
 
-    # Set vault package status.
-    log.write(ctx, "BEFORE set vault package status to unpublished")
-    avu.set_on_coll(ctx, target, constants.IIVAULTSTATUSATTRNAME, constants.vault_package_state.UNPUBLISHED)
-    log.write(ctx, "After set vault package status to unpublished")
-
-    # Set cronjob status.
+    # Set cronjob status to OK.
     if modify_access != b'\x01':
         try:
             msi.set_acl(ctx, "default", "admin:write", user.full_name(ctx), coll)
-        except msi.Error as e:
+        except msi.Error:
             log.write(ctx, "Could not set acl (admin:write) for collection: " + coll)
             return '1'
 
@@ -297,9 +257,44 @@ def folder_secure(ctx, coll):
     if modify_access != b'\x01':
         try:
             msi.set_acl(ctx, "default", "admin:null", user.full_name(ctx), coll)
-        except msi.Error as e:
+        except msi.Error:
             log.write(ctx, "Could not set acl (admin:null) for collection: " + coll)
             return '1'
+
+    # Vault package is ready, set vault package state to UNPUBLISHED.
+    avu.set_on_coll(ctx, target, constants.IIVAULTSTATUSATTRNAME, constants.vault_package_state.UNPUBLISHED)
+
+    # Everything is done, set research folder state to SECURED.
+    try:
+        msi.set_acl(ctx, "recursive", "admin:write", user.full_name(ctx), coll)
+    except msi.Error:
+        log.write(ctx, "Could not set acl (admin:write) for collection: " + coll)
+        return '1'
+
+    parent, chopped_coll = pathutil.chop(coll)
+    while parent != "/" + user.zone(ctx) + "/home":
+        try:
+            msi.set_acl(ctx, "default", "admin:write", user.full_name(ctx), parent)
+        except msi.Error:
+            log.write(ctx, "Could not set ACL on " + parent)
+        parent, chopped_coll = pathutil.chop(parent)
+
+    avu.set_on_coll(ctx, coll, constants.IISTATUSATTRNAME, constants.research_package_state.SECURED)
+
+    try:
+        msi.set_acl(ctx, "recursive", "admin:null", user.full_name(ctx), coll)
+    except msi.Error:
+        log.write(ctx, "Could not set acl (admin:null) for collection: " + coll)
+        return '1'
+
+    parent, chopped_coll = pathutil.chop(coll)
+    while parent != "/" + user.zone(ctx) + "/home":
+        try:
+            msi.set_acl(ctx, "default", "admin:null", user.full_name(ctx), parent)
+        except msi.Error:
+            log.write(ctx, "Could not set ACL (admin:null) on " + parent)
+
+        parent, chopped_coll = pathutil.chop(parent)
 
     # All went well
     return '0'

--- a/vault.py
+++ b/vault.py
@@ -586,13 +586,6 @@ def ingest_object(ctx, parent, item, item_is_collection, destination, origin):
     if item_is_collection:
         # CREATE COLLECTION
         try:
-            if parent == '/' + user.zone(ctx) + '/home':
-                # This is a special case. Dealing with the highest level and 2 collections have to be added
-                # 1. Add the basename for the research collection. Something like research-XXXXX[timestamp]
-                # So chop off /original
-                base_path = pathutil.chop(dest_path)[0]
-                log.write(ctx, 'First add BASE PATH: ' + pathutil.chop(dest_path)[0])
-                msi.coll_create(ctx, pathutil.chop(dest_path)[0], '', irods_types.BytesBuf())
             log.write(ctx, 'coll_create ' + dest_path)
             msi.coll_create(ctx, dest_path, '', irods_types.BytesBuf())
         except msi.Error as e:


### PR DESCRIPTION
This changes the research folder securing process so that securing the research folder is the last step in the process.

If anything fails the research folder remains ACCEPTED and the vault package is INCOMPLETE.

This fixes YDA-3720.

Note: To be fixed later, EPIC PID is registered always, this should be configurable (WIP: https://github.com/UtrechtUniversity/irods-ruleset-uu/tree/epic_config) and the INCOMPLETE state is unknown to the frontend.

