### PR TITLE
Yda 3662 - Mail test functionality

### DIFF
--- a/mail.py
+++ b/mail.py
@@ -12,7 +12,8 @@ from email.mime.text import MIMEText
 from util import *
 
 __all__ = ['rule_mail_new_package_published',
-           'rule_mail_your_package_published']
+           'rule_mail_your_package_published',
+           'rule_mail_test']
 
 
 def send(ctx, to, actor, subject, body):
@@ -161,3 +162,19 @@ DOI:   {} (https://doi.org/{})
 Best regards,
 Yoda system
 """.format(title, doi, doi))
+
+@rule.make(inputs=range(1), outputs=range(1,3))
+def rule_mail_test(ctx, to):
+    return mail_test(ctx, to)
+
+def mail_test(ctx, addressee):
+    return _wrapper(ctx,
+                    to=addressee,
+                    actor='None',
+                    subject='[Yoda] Test mail',
+                    body="""
+Congratulations, you have sent a test mail from your Yoda system.
+
+Best regards,
+Yoda system
+""")

--- a/mail.py
+++ b/mail.py
@@ -14,6 +14,7 @@ from util import *
 __all__ = ['rule_mail_new_package_published',
            'rule_mail_your_package_published',
            'rule_mail_test']
+           
 
 
 def send(ctx, to, actor, subject, body):
@@ -165,11 +166,8 @@ Yoda system
 
 @rule.make(inputs=range(1), outputs=range(1,3))
 def rule_mail_test(ctx, to):
-    return mail_test(ctx, to)
-
-def mail_test(ctx, addressee):
-    return _wrapper(ctx,
-                    to=addressee,
+	return _wrapper(ctx,
+                    to=to,
                     actor='None',
                     subject='[Yoda] Test mail',
                     body="""

--- a/mail.py
+++ b/mail.py
@@ -14,7 +14,6 @@ from util import *
 __all__ = ['rule_mail_new_package_published',
            'rule_mail_your_package_published',
            'rule_mail_test']
-           
 
 
 def send(ctx, to, actor, subject, body):
@@ -164,9 +163,10 @@ Best regards,
 Yoda system
 """.format(title, doi, doi))
 
-@rule.make(inputs=range(1), outputs=range(1,3))
+
+@rule.make(inputs=range(1), outputs=range(1, 3))
 def rule_mail_test(ctx, to):
-	return _wrapper(ctx,
+    return _wrapper(ctx,
                     to=to,
                     actor='None',
                     subject='[Yoda] Test mail',

--- a/tools/mail-test.r
+++ b/tools/mail-test.r
@@ -1,0 +1,17 @@
+mail_test
+{
+	*status="";
+	*info="";
+
+        rule_mail_test( *to, *status, *info);
+
+	if ( *status == '0' ) then {
+		writeLine("stdout", "Succesfully executed rule for testing email with destination <" ++ *to ++ ">");
+	}
+	else {
+		writeLine("stdout", "An error occurred during mail test:\n" ++ *info);
+	}
+}
+
+input *to=""
+output ruleExecOut

--- a/tools/mail-test.sh
+++ b/tools/mail-test.sh
@@ -1,0 +1,1 @@
+irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/irods-ruleset-uu/tools/mail-test.r '*to="'$1'"'


### PR DESCRIPTION
Things to consider:

1. in the ticket it was specified to have some information in the sent email about which instance is sending the email. From my understanding I could _maybe_ find out the name given to the portal, but that is not by definition identifying. Since the user executing the test has to pass the target email address the user can know for sure that they sent the email and they then know/can find out what instance they are on.

2. This should only be executable by admins. I purposely left the permissions for the script the same as those of others in the tools folder, since all those scripts should dnot be accessible for regular users. Is it fair to assume this is safe because users cannot login directly to the machine and they also cannot execute the rules related to them? Or should permissions be said explicitly as well?