### PR TITLE
Fixed level of 'required' property

### DIFF
--- a/datarequest/schemas/youth/datarequest/schema.json
+++ b/datarequest/schemas/youth/datarequest/schema.json
@@ -58,17 +58,17 @@
                 "$ref": "#/definitions/stringNormal",
                 "title": "Phone"
               }
-            }
-          },
-          "required": [
-            "name",
-            "institution",
-            "department",
-            "academic_role",
-            "work_address",
-            "email",
-            "phone"
-          ]
+            },
+            "required": [
+              "name",
+              "institution",
+              "department",
+              "academic_role",
+              "work_address",
+              "email",
+              "phone"
+            ]
+	  }
         },
         "dmc_contact": {
           "type": "string",


### PR DESCRIPTION
Problem: at least 1 contact should be filled in, but wasn't checked

Solution: By default an empty form is created and empty values were accepted. Fixing the "required' property solved the issue.

Note: some more detailed validation could be possible (check email for valid format, phone number, etc.)