### PR TITLE
Notifications in research and vault workflows

### DIFF
--- a/folder.py
+++ b/folder.py
@@ -532,7 +532,7 @@ def set_submitter(ctx, path, actor):
 def get_submitter(ctx, path):
     """Set submitter of folder for the vault."""
     attribute = constants.UUORGMETADATAPREFIX + "submitted_actor"
-    org_metadata = get_org_metadata(ctx, path)
+    org_metadata = dict(get_org_metadata(ctx, path))
 
     if attribute in org_metadata:
         return org_metadata[attribute]
@@ -549,7 +549,7 @@ def set_accepter(ctx, path, actor):
 def get_accepter(ctx, path):
     """Set accepter of folder for the vault."""
     attribute = constants.UUORGMETADATAPREFIX + "accepted_actor"
-    org_metadata = get_org_metadata(ctx, path)
+    org_metadata = dict(get_org_metadata(ctx, path))
 
     if attribute in org_metadata:
         return org_metadata[attribute]

--- a/folder.py
+++ b/folder.py
@@ -513,3 +513,45 @@ def datamanager_exists(ctx, coll):
     category = group.get_category(ctx, group_name)
 
     return group.exists(ctx, "datamanager-" + category)
+
+
+def get_datamanagers(ctx, coll):
+    """Retrieve datamanagers for a given collection."""
+    group_name = collection_group_name(ctx, coll)
+    category = group.get_category(ctx, group_name)
+
+    return group.members(ctx, "datamanager-" + category)
+
+
+def set_submitter(ctx, path, actor):
+    """Set submitter of folder for the vault."""
+    attribute = constants.UUORGMETADATAPREFIX + "submitted_actor"
+    avu.set_on_coll(ctx, path, attribute, actor)
+
+
+def get_submitter(ctx, path):
+    """Set submitter of folder for the vault."""
+    attribute = constants.UUORGMETADATAPREFIX + "submitted_actor"
+    org_metadata = get_org_metadata(ctx, path)
+
+    if attribute in org_metadata:
+        return org_metadata[attribute]
+    else:
+        return None
+
+
+def set_accepter(ctx, path, actor):
+    """Set accepter of folder for the vault."""
+    attribute = constants.UUORGMETADATAPREFIX + "accepted_actor"
+    avu.set_on_coll(ctx, path, attribute, actor)
+
+
+def get_accepter(ctx, path):
+    """Set accepter of folder for the vault."""
+    attribute = constants.UUORGMETADATAPREFIX + "accepted_actor"
+    org_metadata = get_org_metadata(ctx, path)
+
+    if attribute in org_metadata:
+        return org_metadata[attribute]
+    else:
+        return None

--- a/notifications.py
+++ b/notifications.py
@@ -18,16 +18,18 @@ __all__ = ['api_notifications_load',
 NOTIFICATION_KEY = constants.UUORGMETADATAPREFIX + "notification"
 
 
-def set(ctx, receiver, message):
+def set(ctx, actor, receiver, target, message):
     """Save user notification.
 
     :param ctx:      Combined type of a callback and rei struct
-    :param receiver: Receiver of notification message
+    :param actor:    Actor of notification message
+    :param receiver: Receiving user of notification message
+    :param target:   Target path of the notification
     :param message:  Notification message for user
     """
     if user.exists(ctx, receiver):
         timestamp = int(time.time())
-        notification = {"timestamp": timestamp, "message": message}
+        notification = {"timestamp": timestamp, "actor": actor, "target": target, "message": message}
         ctx.uuUserModify(receiver, "{}_{}".format(NOTIFICATION_KEY, str(timestamp)), json.dumps(notification), '', '')
 
 

--- a/notifications.py
+++ b/notifications.py
@@ -56,10 +56,10 @@ def api_notifications_load(ctx):
             space, _, group, subpath = pathutil.info(notification["target"])
             if space is pathutil.Space.RESEARCH:
                 notification["data_package"] = pathutil.basename(subpath)
-                notification["link"] = "/research?dir={}/{}".format(group, subpath)
+                notification["link"] = "/research?dir=/{}/{}".format(group, subpath)
             elif space is pathutil.Space.VAULT:
                 notification["data_package"] = pathutil.basename(subpath)
-                notification["link"] = "/vault?dir={}/{}".format(group, subpath)
+                notification["link"] = "/vault?dir=/{}/{}".format(group, subpath)
 
             notifications.append(notification)
         except Exception:

--- a/notifications.py
+++ b/notifications.py
@@ -50,6 +50,17 @@ def api_notifications_load(ctx):
         try:
             notification = jsonutil.parse(result)
             notification["datetime"] = (datetime.fromtimestamp(notification["timestamp"])).strftime('%Y-%m-%d %H:%M')
+            notification["actor"] = user.from_str(ctx, notification["actor"])[0]
+
+            # Get data package and link from target path for research and vault packages.
+            space, _, group, subpath = pathutil.info(notification["target"])
+            if space is pathutil.Space.RESEARCH:
+                notification["data_package"] = pathutil.basename(subpath)
+                notification["link"] = "/research?dir={}/{}".format(group, subpath)
+            elif space is pathutil.Space.VAULT:
+                notification["data_package"] = pathutil.basename(subpath)
+                notification["link"] = "/vault?dir={}/{}".format(group, subpath)
+
             notifications.append(notification)
         except Exception:
             continue

--- a/notifications.py
+++ b/notifications.py
@@ -13,8 +13,7 @@ from util import *
 from util.query import Query
 
 __all__ = ['api_notifications_load',
-           'api_notifications_dismiss',
-           'rule_notification_set']
+           'api_notifications_dismiss']
 
 NOTIFICATION_KEY = constants.UUORGMETADATAPREFIX + "notification"
 
@@ -26,20 +25,10 @@ def set(ctx, receiver, message):
     :param receiver: Receiver of notification message
     :param message:  Notification message for user
     """
-    timestamp = int(time.time())
-    notification = {"timestamp": timestamp, "message": message}
-    ctx.uuUserModify(receiver, "{}_{}".format(NOTIFICATION_KEY, str(timestamp)), json.dumps(notification), '', '')
-
-
-@rule.make(inputs=[0, 1], outputs=[2])
-def rule_notification_set(ctx, receiver, message):
-    """Rule interface for setting notification (testing only).
-
-    :param ctx:      Combined type of a callback and rei struct
-    :param receiver: Receiver of notification message
-    :param message:  Notification message for user
-    """
-    set(ctx, receiver, message)
+    if user.exists(ctx, receiver):
+        timestamp = int(time.time())
+        notification = {"timestamp": timestamp, "message": message}
+        ctx.uuUserModify(receiver, "{}_{}".format(NOTIFICATION_KEY, str(timestamp)), json.dumps(notification), '', '')
 
 
 @api.make()
@@ -63,7 +52,8 @@ def api_notifications_load(ctx):
         except Exception:
             continue
 
-    return notifications
+    # Return notifications sorted on timestamp
+    return sorted(notifications, key=lambda k: k['timestamp'], reverse=True)
 
 
 @api.make()

--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -103,7 +103,7 @@ def post_status_transition(ctx, path, actor, status):
         if folder.datamanager_exists(ctx, path):
             # Send notifications to datamanagers
             datamanagers = folder.get_datamanagers(ctx, path)
-            message = "Data package submitted data package"
+            message = "Data package submitted for the vault"
             for datamanager in datamanagers:
                 datamanager = '{}#{}'.format(*datamanager)
                 notifications.set(ctx, actor, datamanager, path, message)
@@ -118,10 +118,10 @@ def post_status_transition(ctx, path, actor, status):
 
         provenance.log_action(ctx, actor, path, "accepted for vault")
 
-        # Store actor of accepted for vault
+        # Store actor of accepted for vault.
         folder.set_accepter(ctx, path, actor)
 
-        # Send notifications to submitter
+        # Send notifications to submitter.
         submitter = folder.get_submitter(ctx, path)
         message = "Data package accepted for vault"
         notifications.set(ctx, actor, submitter, path, message)

--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -105,6 +105,7 @@ def post_status_transition(ctx, path, actor, status):
             datamanagers = folder.get_datamanagers(ctx, path)
             message = "User {} submitted data package {} for vault".format(actor, path)
             for datamanager in datamanagers:
+                datamanager = '{}#{}'.format(*datamanager)
                 notifications.set(ctx, datamanager, message)
         else:
             # Set status to accepted if group has no datamanager.

--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -103,10 +103,10 @@ def post_status_transition(ctx, path, actor, status):
         if folder.datamanager_exists(ctx, path):
             # Send notifications to datamanagers
             datamanagers = folder.get_datamanagers(ctx, path)
-            message = "User {} submitted data package {} for vault".format(actor, path)
+            message = "Data package submitted data package"
             for datamanager in datamanagers:
                 datamanager = '{}#{}'.format(*datamanager)
-                notifications.set(ctx, datamanager, message)
+                notifications.set(ctx, actor, datamanager, path, message)
         else:
             # Set status to accepted if group has no datamanager.
             folder.set_status(ctx, path, constants.research_package_state.ACCEPTED)
@@ -123,8 +123,8 @@ def post_status_transition(ctx, path, actor, status):
 
         # Send notifications to submitter
         submitter = folder.get_submitter(ctx, path)
-        message = "User {} accepted data package {} for vault".format(actor, path)
-        notifications.set(ctx, submitter, message)
+        message = "Data package accepted for vault"
+        notifications.set(ctx, actor, submitter, path, message)
 
         # Set state to secure package in vault space.
         attribute = constants.UUORGMETADATAPREFIX + "cronjob_copy_to_vault"
@@ -147,8 +147,8 @@ def post_status_transition(ctx, path, actor, status):
 
         # Send notifications to submitter
         submitter = folder.get_submitter(ctx, path)
-        message = "User {} rejected data package {} for vault".format(actor, path)
-        notifications.set(ctx, submitter, message)
+        message = "Data package rejected for vault"
+        notifications.set(ctx, actor, submitter, path, message)
 
     elif status is constants.research_package_state.SECURED:
         actor = "system"
@@ -157,6 +157,6 @@ def post_status_transition(ctx, path, actor, status):
         # Send notifications to submitter and accepter
         submitter = folder.get_submitter(ctx, path)
         accepter = folder.get_accepter(ctx, path)
-        message = "Data package {} is secured in vault".format(path)
-        notifications.set(ctx, submitter, message)
-        notifications.set(ctx, accepter, message)
+        message = "Data package secured in vault"
+        notifications.set(ctx, actor, submitter, path, message)
+        notifications.set(ctx, actor, accepter, path, message)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 ignore=E221,E241,E402,E501,W503,W605,F403,F405,F841,F999
 import-order-style = smarkets
 exclude=__init__.py,tools
-application-import-names=avu_json,conftest,util,api,config,constants,datacite,datarequest,data_object,epic,error,folder,group,json_datacite41,json_landing_page,jsonutil,log,mail,meta,meta_form,msi,schema,schema_transformation,schema_transformations,settings,pathutil,provenance,policies_intake,policies_datapackage_status,policies_folder_status,policies_datarequest_status,publication,query,rule,user,vault,vault_xml_to_json
+application-import-names=avu_json,conftest,util,api,config,constants,datacite,datarequest,data_object,epic,error,folder,group,json_datacite41,json_landing_page,jsonutil,log,mail,meta,meta_form,msi,notifications,schema,schema_transformation,schema_transformations,settings,pathutil,provenance,policies_intake,policies_datapackage_status,policies_folder_status,policies_datarequest_status,publication,query,rule,user,vault,vault_xml_to_json
 strictness=short
 docstring_style=sphinx

--- a/uuGroupPolicyChecks.r
+++ b/uuGroupPolicyChecks.r
@@ -440,15 +440,17 @@ uuUserPolicyCanUserModify(*actor, *userName, *attribute, *allowed, *reason) {
 	*allowed = 0;
 	*reason  = "";
 
-	if (*actor == *userName) {
-        if (*attribute == "org_settings_mail_notifications") {
+    # User setting: mail notifications
+    if (*attribute == "org_settings_mail_notifications") {
+        if (*actor == *userName) {
             *allowed = 1;
-        } else if (trimr(*attribute, "_") == "org_notification") {
-            *allowed = 1;
-		} else {
-			*reason = "Invalid user attribute name.";
-		}
+        } else {
+            *reason = "Cannot modify settings of other user.";
+        }
+    # User notifications
+    } else if (trimr(*attribute, "_") == "org_notification") {
+        *allowed = 1;
 	} else {
-		*reason = "Cannot modify attributes of other user.";
+		*reason = "Invalid user attribute name.";
 	}
 }

--- a/vault.py
+++ b/vault.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Functions to copy packages to the vault and manage permissions of vault packages."""
 
-__copyright__ = 'Copyright (c) 2019-2020, Utrecht University'
+__copyright__ = 'Copyright (c) 2019-2021, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import itertools
@@ -985,3 +985,37 @@ def vault_request_status_transitions(ctx, coll, new_vault_status):
     avu.set_on_coll(ctx, actor_group_path, constants.UUORGMETADATAPREFIX + 'vault_status_action_' + coll_id, 'PENDING')
 
     return ['', '']
+
+
+def set_submitter(ctx, path, actor):
+    """Set submitter of data package for publication."""
+    attribute = constants.UUORGMETADATAPREFIX + "publication_submission_actor"
+    avu.set_on_coll(ctx, path, attribute, actor)
+
+
+def get_submitter(ctx, path):
+    """Set submitter of data package for publication."""
+    attribute = constants.UUORGMETADATAPREFIX + "publication_submission_actor"
+    org_metadata = dict(get_org_metadata(ctx, path))
+
+    if attribute in org_metadata:
+        return org_metadata[attribute]
+    else:
+        return None
+
+
+def set_approver(ctx, path, actor):
+    """Set approver of data package for publication."""
+    attribute = constants.UUORGMETADATAPREFIX + "publication_approval_actor"
+    avu.set_on_coll(ctx, path, attribute, actor)
+
+
+def get_approver(ctx, path):
+    """Set approver of data package for publication."""
+    attribute = constants.UUORGMETADATAPREFIX + "publication_approval_actor"
+    org_metadata = dict(get_org_metadata(ctx, path))
+
+    if attribute in org_metadata:
+        return org_metadata[attribute]
+    else:
+        return None


### PR DESCRIPTION
Add notifications on these actions:

Research:
- submit (notifies datamanagers)
- accept (notifies submitter)
- reject (notifies submitter)
- secured (notifies submitter and accepter)

Vault:
- submit (notifies datamanagers)
- approve (notifies submitter)
- published (notifies submitter and approver)