### PR TITLE
Statistics: fix bug YDA-4103

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -525,7 +525,7 @@ def rule_resource_store_monthly_storage_statistics(ctx):
                     if folder == 'self':
                         whereClause = "COLL_NAME = '" + path + "'"
                     else:
-                        whereClause = "COLL_NAME like '" + path + "%'"
+                        whereClause = "COLL_NAME like '" + path + "/%'"
 
                     iter = genquery.row_iterator(
                         "SUM(DATA_SIZE), RESC_NAME",


### PR DESCRIPTION
Size of some groups was counted wrong when one group name was prefix
of another one, e.g. data objects of group "research-jansen" were
included in size of group "research-jan"

If PR is accepted, please cherry-pick to release-1.6 and release-1.7 branches as well.