### PR TITLE
Fix YDA-4115

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -539,8 +539,8 @@ def rule_resource_store_monthly_storage_statistics(ctx):
                         tier_storage[the_tier] += int(row[0])
 
             # 3) Revision erea
-            revision_path = '/' + zone + '/' + constants.UUREVISIONCOLLECTION + '/' + group
-            whereClause = "COLL_NAME like '" + revision_path + "%'"
+            revision_path = '/{}{}/{}'.format(zone, constants.UUREVISIONCOLLECTION, group)
+            whereClause = "COLL_NAME like '" + revision_path + "/%'"
             iter = genquery.row_iterator(
                 "SUM(DATA_SIZE), RESC_NAME",
                 whereClause,


### PR DESCRIPTION
Size of revisions wasn't counted in statistics job because of
double slash in collection search path (UUREVISIONCOLLECTION already
starts with a slash, so doesn't need to be prefixed with a slash).

Also fixed potential issue where two group names with a common prefix
(e.g. research-jan and research-jansen) could result in a situation
where the contents of the group with the long name will be counted
towards the statistics of the group with the short name.