### PR TITLE
Pyportal test provenance

### DIFF
--- a/tests/features/ui/ui_publication.feature
+++ b/tests/features/ui/ui_publication.feature
@@ -2,44 +2,45 @@ Feature: Publication of geo data
 
 		
     Scenario Outline: Publication of teclab datapackage and test landing page output
-        #ui_vault:
         Given user "researcher" is logged in
         And module "research" is shown
         When user browses to folder "<folder>"
-    #    And user checks provenance info research
-#        And user submits the folder
-#        Then the folder status is "Submitted"
+        And user submits the folder
+        Then the folder status is "Submitted"
         Given user is not logged in
 
-#        Given user "datamanager" is logged in
-#        And module "research" is shown
-#        When user browses to folder "<folder>"
-#        And user accepts the folder
-#        Then the folder status is "Accepted"
-#        Given user is not logged in
-
-#        Given user "researcher" is logged in
-#        And module "vault" is shown
-#        When user browses to data package in "<vault>"
-#        And user submits the data package for publication
-#        Then the data package status is "Submitted for publication"
-#        Given user is not logged in
-
-#        Given user "datamanager" is logged in
-#        And module "vault" is shown
-#        When user browses to data package in "<vault>"
-#        And user approves the data package for publication
-#        Then the data package status is "Approved for publication"
-#        Given user is not logged in
+        Given user "datamanager" is logged in
+        And module "research" is shown
+        When user browses to folder "<folder>"
+        And user accepts the folder
+        Then the folder status is "Accepted"
+        Given user is not logged in
 
         Given user "researcher" is logged in
         And module "vault" is shown
         When user browses to data package in "<vault>"
-        user checks provenance info vault
-#        Then the data package status is "Published"
-#        And user downloads relevant files of datapackage
-#        Then user opens landingpage through system metadata
-#        And user checks landingpage content 
+        And user submits the data package for publication
+        Then the data package status is "Submitted for publication"
+        Given user is not logged in
+
+        Given user "datamanager" is logged in
+        And module "vault" is shown
+        When user browses to data package in "<vault>"
+        And user approves the data package for publication
+        Then the data package status is "Approved for publication"
+        Given user is not logged in
+
+        Given user "researcher" is logged in
+        And module "research" is shown
+        When user browses to folder "<folder>"
+        And user checks provenance info research
+        And module "vault" is shown
+        When user browses to data package in "<vault>"
+        And user checks provenance info vault
+        Then the data package status is "Published"
+        And user downloads relevant files of datapackage
+        Then user opens landingpage through system metadata
+        And user checks landingpage content 
 
     Examples:
         | folder            | vault          |  

--- a/tests/features/ui/ui_publication.feature
+++ b/tests/features/ui/ui_publication.feature
@@ -6,38 +6,40 @@ Feature: Publication of geo data
         Given user "researcher" is logged in
         And module "research" is shown
         When user browses to folder "<folder>"
-        And user submits the folder
-        Then the folder status is "Submitted"
+    #    And user checks provenance info research
+#        And user submits the folder
+#        Then the folder status is "Submitted"
         Given user is not logged in
 
-        Given user "datamanager" is logged in
-        And module "research" is shown
-        When user browses to folder "<folder>"
-        And user accepts the folder
-        Then the folder status is "Accepted"
-        Given user is not logged in
+#        Given user "datamanager" is logged in
+#        And module "research" is shown
+#        When user browses to folder "<folder>"
+#        And user accepts the folder
+#        Then the folder status is "Accepted"
+#        Given user is not logged in
+
+#        Given user "researcher" is logged in
+#        And module "vault" is shown
+#        When user browses to data package in "<vault>"
+#        And user submits the data package for publication
+#        Then the data package status is "Submitted for publication"
+#        Given user is not logged in
+
+#        Given user "datamanager" is logged in
+#        And module "vault" is shown
+#        When user browses to data package in "<vault>"
+#        And user approves the data package for publication
+#        Then the data package status is "Approved for publication"
+#        Given user is not logged in
 
         Given user "researcher" is logged in
         And module "vault" is shown
         When user browses to data package in "<vault>"
-        And user submits the data package for publication
-        Then the data package status is "Submitted for publication"
-        Given user is not logged in
-
-        Given user "datamanager" is logged in
-        And module "vault" is shown
-        When user browses to data package in "<vault>"
-        And user approves the data package for publication
-        Then the data package status is "Approved for publication"
-        Given user is not logged in
-
-        Given user "researcher" is logged in
-        And module "vault" is shown
-        When user browses to data package in "<vault>"
-        Then the data package status is "Published"
-        And user downloads relevant files of datapackage
-        Then user opens landingpage through system metadata
-        And user checks landingpage content 
+        user checks provenance info vault
+#        Then the data package status is "Published"
+#        And user downloads relevant files of datapackage
+#        Then user opens landingpage through system metadata
+#        And user checks landingpage content 
 
     Examples:
         | folder            | vault          |  

--- a/tests/step_defs/ui/test_ui_publication.py
+++ b/tests/step_defs/ui/test_ui_publication.py
@@ -19,6 +19,36 @@ from pytest_bdd import (
 scenarios('../../features/ui/ui_publication.feature')
 
 
+@when('user checks provenance info research')
+def ui_check_provenance_research(browser):
+    # Check presence and chronological order of provenance
+    # precondition is that in the correct research folder already
+	# This test can be executed repeatedly as always the n top statuses of the package in research will be checked
+    # eventhough the folder is used several times in a different test run
+    time.sleep(10)
+    browser.find_by_css('.actionlog-icon')[0].click()
+    time.sleep(10)
+    action_log_rows = browser.find_by_css('.list-group-item-action')
+    # Chronological (backwards) status changes 
+    prov_statuses = ['Secured in vault', 'Accepted for vault', 'Submitted for vault']
+    for index in range(0, len(prov_statuses)):
+        assert action_log_rows[index].value.find(prov_statuses[index]) != -1
+
+
+@when('user checks provenance info vault')
+def ui_check_provenance_vault(browser):
+    # Check presence and chronological order of provenance
+    # precondition is that in the correct vault folder (highest level datapackage) already
+    time.sleep(10)
+    browser.find_by_css('.actionlog-icon')[0].click()
+    time.sleep(10)
+    action_log_rows = browser.find_by_css('.list-group-item-action')
+    # Chronological (backward) status changes 
+    prov_statuses = ['Published', 'Approved for publication', 'Submitted for publication', 'Secured in vault', 'Accepted for vault', 'Submitted for vault']
+    for index in range(0, len(prov_statuses)):
+        assert action_log_rows[index].value.find(prov_statuses[index]) != -1
+
+
 @then('user downloads relevant files of datapackage')
 def ui_pub_download_relevant_files(browser):
     # License file and yoda-metadata.json are present at toplevel
@@ -87,7 +117,7 @@ def ui_browse_data_package(browser, vault):
             browser.find_by_id('file-browser_next').click()
 
     browser.find_by_css('.sorting_asc').click()
-
+    time.sleep(10)
     research = vault.replace("vault-", "research-")
     data_packages = browser.links.find_by_partial_text(research)
     data_packages.click()

--- a/tests/step_defs/ui/test_ui_publication.py
+++ b/tests/step_defs/ui/test_ui_publication.py
@@ -23,13 +23,12 @@ scenarios('../../features/ui/ui_publication.feature')
 def ui_check_provenance_research(browser):
     # Check presence and chronological order of provenance
     # precondition is that in the correct research folder already
-	# This test can be executed repeatedly as always the n top statuses of the package in research will be checked
+    # This test can be executed repeatedly as always the n top statuses of the package in research will be checked
     # eventhough the folder is used several times in a different test run
-    time.sleep(10)
+    time.sleep(10)  # This sleep cannot be added to next line as wait_time -> it doesn't work then
     browser.find_by_css('.actionlog-icon')[0].click()
-    time.sleep(10)
     action_log_rows = browser.find_by_css('.list-group-item-action')
-    # Chronological (backwards) status changes 
+    # Chronological (backwards) status changes
     prov_statuses = ['Secured in vault', 'Accepted for vault', 'Submitted for vault']
     for index in range(0, len(prov_statuses)):
         assert action_log_rows[index].value.find(prov_statuses[index]) != -1
@@ -39,11 +38,10 @@ def ui_check_provenance_research(browser):
 def ui_check_provenance_vault(browser):
     # Check presence and chronological order of provenance
     # precondition is that in the correct vault folder (highest level datapackage) already
-    time.sleep(10)
+    time.sleep(10)  # This sleep cannot be added to next line as wait_time -> it doesn't work then
     browser.find_by_css('.actionlog-icon')[0].click()
-    time.sleep(10)
     action_log_rows = browser.find_by_css('.list-group-item-action')
-    # Chronological (backward) status changes 
+    # Chronological (backward) status changes
     prov_statuses = ['Published', 'Approved for publication', 'Submitted for publication', 'Secured in vault', 'Accepted for vault', 'Submitted for vault']
     for index in range(0, len(prov_statuses)):
         assert action_log_rows[index].value.find(prov_statuses[index]) != -1


### PR DESCRIPTION
Hey Lazlo,
The sleeps present cannot be left out. Nor can they be added as wait_time on my system.

The provenance log is tested for both completeness and correctness of time order of the statuses