### PR TITLE
Pyportal test notifications

### DIFF
--- a/tests/features/ui/ui_publication.feature
+++ b/tests/features/ui/ui_publication.feature
@@ -1,8 +1,12 @@
 Feature: Publication of geo data
 
-		
     Scenario Outline: Publication of teclab datapackage and test landing page output
+        Given user "datamanager" is logged in
+        When all notifications are reset
+        Given user is not logged in
+
         Given user "researcher" is logged in
+        When all notifications are reset
         And module "research" is shown
         When user browses to folder "<folder>"
         And user submits the folder
@@ -10,6 +14,7 @@ Feature: Publication of geo data
         Given user is not logged in
 
         Given user "datamanager" is logged in
+        When user checks and clears notifications for status "Submitted"
         And module "research" is shown
         When user browses to folder "<folder>"
         And user accepts the folder
@@ -17,6 +22,7 @@ Feature: Publication of geo data
         Given user is not logged in
 
         Given user "researcher" is logged in
+        When user checks and clears notifications for status "Accepted"
         And module "vault" is shown
         When user browses to data package in "<vault>"
         And user submits the data package for publication
@@ -24,6 +30,7 @@ Feature: Publication of geo data
         Given user is not logged in
 
         Given user "datamanager" is logged in
+        When user checks and clears notifications for status "Submitted for publication"
         And module "vault" is shown
         When user browses to data package in "<vault>"
         And user approves the data package for publication
@@ -31,6 +38,7 @@ Feature: Publication of geo data
         Given user is not logged in
 
         Given user "researcher" is logged in
+        When user checks and clears notifications for status "Approved for publication"		
         And module "research" is shown
         When user browses to folder "<folder>"
         And user checks provenance info research
@@ -41,7 +49,7 @@ Feature: Publication of geo data
         And user downloads relevant files of datapackage
         Then user opens landingpage through system metadata
         And user checks landingpage content 
-
+		
     Examples:
         | folder            | vault          |  
         | research-teclab-0 | vault-teclab-0 |

--- a/tests/step_defs/ui/test_ui_publication.py
+++ b/tests/step_defs/ui/test_ui_publication.py
@@ -25,8 +25,8 @@ def ui_reset_notifcations(browser):
     browser.links.find_by_partial_text('Notifications')[0].click()
 
     time.sleep(5)
-	
-	# reset all present notifications if any present
+
+    # reset all present notifications if any present
     if len(browser.find_by_css('.list-group-item-action')) > 0:
         browser.find_by_id('notifications_dismiss_all').click()
 
@@ -34,7 +34,7 @@ def ui_reset_notifcations(browser):
 @when(parsers.parse('user checks and clears notifications for status "{status}"'))
 def ui_notifications(browser, status):
     status_text = {'Submitted': ['Data package submitted'],
-	               'Accepted': ['Data package secured', 'Data package accepted for vault'],
+                   'Accepted': ['Data package secured', 'Data package accepted for vault'],
                    'Submitted for publication': ['Data package submitted for publication', 'Data package secured'],
                    'Approved for publication': ['Data package published', 'Data package approved for publication']}
 
@@ -42,14 +42,14 @@ def ui_notifications(browser, status):
     browser.links.find_by_partial_text('Notifications')[0].click()
 
     time.sleep(5)
-	
+
     assert len(browser.find_by_css('.list-group-item-action')) == len(status_text[status])
 
     index = 0
     for status_item in status_text[status]:
         assert browser.find_by_css('.list-group-item-action')[index].value.find(status_item) != -1
         index = index + 1
-	
+
     browser.find_by_id('notifications_dismiss_all').click()
 
     time.sleep(5)

--- a/tests/step_defs/ui/test_ui_publication.py
+++ b/tests/step_defs/ui/test_ui_publication.py
@@ -19,6 +19,45 @@ from pytest_bdd import (
 scenarios('../../features/ui/ui_publication.feature')
 
 
+@when('all notifications are reset')
+def ui_reset_notifcations(browser):
+    browser.find_by_id('userDropdown').click()
+    browser.links.find_by_partial_text('Notifications')[0].click()
+
+    time.sleep(5)
+	
+	# reset all present notifications if any present
+    if len(browser.find_by_css('.list-group-item-action')) > 0:
+        browser.find_by_id('notifications_dismiss_all').click()
+
+
+@when(parsers.parse('user checks and clears notifications for status "{status}"'))
+def ui_notifications(browser, status):
+    status_text = {'Submitted': ['Data package submitted'],
+	               'Accepted': ['Data package secured', 'Data package accepted for vault'],
+                   'Submitted for publication': ['Data package submitted for publication', 'Data package secured'],
+                   'Approved for publication': ['Data package published', 'Data package approved for publication']}
+
+    browser.find_by_id('userDropdown').click()
+    browser.links.find_by_partial_text('Notifications')[0].click()
+
+    time.sleep(5)
+	
+    assert len(browser.find_by_css('.list-group-item-action')) == len(status_text[status])
+
+    index = 0
+    for status_item in status_text[status]:
+        assert browser.find_by_css('.list-group-item-action')[index].value.find(status_item) != -1
+        index = index + 1
+	
+    browser.find_by_id('notifications_dismiss_all').click()
+
+    time.sleep(5)
+
+    # Check whether all notifications were cleared
+    assert len(browser.find_by_css('.list-group-item-action')) == 0
+
+
 @when('user checks provenance info research')
 def ui_check_provenance_research(browser):
     # Check presence and chronological order of provenance
@@ -72,7 +111,7 @@ def ui_pub_open_system_metadata(browser):
 @then('user checks landingpage content')
 def ui_pub_check_landingpage_content(browser, tmpdir):
     tags = browser.find_by_css('.tag')
-    assert len(tags) == 10  # schema dependant
+    assert len(tags) == 10  # Directly linked to the yoda-metadata.json file that is put here by ansible for testing purposes.
 
     # Build list with tag values
     landingpage_tag_values = []
@@ -138,7 +177,7 @@ def ui_folder_accept(browser):
 # folder
 @then(parsers.parse('the folder status is "{status}"'))
 def ui_folder_status(browser, status):
-    time.sleep(10)
+    time.sleep(20)
     badge = browser.find_by_id('statusBadge')
     if status in ["Unlocked", "Unsubmitted"]:
         assert badge.value == ""


### PR DESCRIPTION
Hey Lazlo,
Had to add several sleeps. Even had to increase the sleeptime in ui_folder_status

Anyhow, this test automation addition checks the presence and time order of notifications after each action of an actor (researcher and datamanager) within the entire publication process. 
Rejection is not taken into account in this publciation process yet. Therefore, the related notifications are not checked either.

The TA clears the notification after each check so that the following check of notifications are solely linked to the last action of the previous actor
 
