### PR TITLE
Dependencies: pin contextlib2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests==2.25.1
 pyrsistent==0.15.7
 configparser==4.0.2
 zipp==1.2.0
+contextlib2==0.6.0.post1
 importlib-metadata==2.1.1
 jsonschema==3.2.0
 pathvalidate==0.29.1


### PR DESCRIPTION
The newest version does not support Python 2.7 anymore, which can cause dependency problems.

If PR is accepted, please cherry-pick to release-1.6 and release-1.7 branches as well.