### PR TITLE
YDA-4209 workaround for GenQuery issue with delete

### DIFF
--- a/policies.py
+++ b/policies.py
@@ -53,7 +53,7 @@ def can_coll_delete(ctx, actor, coll):
         return policy.fail('Cannot delete or move collections directly under /home')
 
     if pathutil.info(coll).space is pathutil.Space.RESEARCH:
-        if folder.has_locks(ctx, coll) and not user.is_admin(ctx, actor):
+        if not user.is_admin(ctx, actor) and folder.has_locks(ctx, coll):
             return policy.fail('Folder or subfolder is locked')
 
     if pathutil.info(coll).space is pathutil.Space.INTAKE:
@@ -113,7 +113,7 @@ def can_data_delete(ctx, actor, path):
         return policy.fail('Cannot delete or move data directly under /home')
 
     if pathutil.info(path).space is pathutil.Space.RESEARCH:
-        if folder.is_data_locked(ctx, path) and not user.is_admin(ctx, actor):
+        if not user.is_admin(ctx, actor) and folder.is_data_locked(ctx, path):
             return policy.fail('Folder is locked')
 
     if pathutil.info(path).space is pathutil.Space.INTAKE:


### PR DESCRIPTION
This is a partial workaround for GenQuery bugs that result in
errors when called indirectly by the deletion policies
(see YDA-4209). By first checking that the user is a rodsUser
(not an admin), this will short circuit the queries for admins,
so that admins can circumvent GenQuery bugs when deleting
objects/collections in the research space.

If accepted, please cherry-pick into release-1.7 branch as well.