### PR TITLE
YDA-4251: fix intake scan WEPV issue

### DIFF
--- a/intake_scan.py
+++ b/intake_scan.py
@@ -40,7 +40,7 @@ def intake_scan_collection(ctx, root, scope, in_dataset):
         if in_dataset:
             apply_dataset_metadata(ctx, path, scope, False, False)
         else:
-            subscope = intake_extract_tokens_from_name(ctx, row[1], row[0], False, scope)
+            subscope = intake_extract_tokens_from_name(ctx, row[1], row[0], False, scope.copy())
 
             if intake_tokens_identify_dataset(subscope):
                 # We found a top-level dataset data object.


### PR DESCRIPTION
This fixes a bug in intake scans:

WEPV elements of data objects could in some situations be
wrongly applied to unrelated collections, since
the function to parse WEPV elements in file names was
using a dictionary that was later reused for registering WEPV
elements in unrelated collections.

PR is ready for review; also to be cherry-picked to release-1.7 