### PR TITLE
YDA-4216:trigger policies on resources not in tree

### DIFF
--- a/policies.py
+++ b/policies.py
@@ -479,16 +479,30 @@ def py_acPreProcForExecCmd(ctx, cmd, args, addr, hint):
     return policy.fail('No execcmd privileges for this command')
 
 
+# Internal function to determine whether changes to data objects on a particular
+# resource need to trigger policies (e.g. asynchronous replication) by default.
+def resource_should_trigger_policies(resource):
+    if resource in config.resource_primary:
+        return True
+
+    for pattern in config.resource_trigger_pol:
+        if re.match(pattern, resource):
+            return True
+
+    return False
+
+
 @rule.make()
 def pep_resource_modified_post(ctx, instance_name, _ctx, out):
-    if instance_name not in config.resource_primary or not config.resource_replica:
+    if not resource_should_trigger_policies(instance_name):
         return
 
     path = _ctx.map()['logical_path']
     zone = _ctx.map()['user_rods_zone']
     username = _ctx.map()['user_user_name']
 
-    ctx.uuReplicateAsynchronously(path, instance_name, config.resource_replica)
+    if config.resource_replica:
+        ctx.uuReplicateAsynchronously(path, instance_name, config.resource_replica)
 
     info = pathutil.info(path)
 

--- a/util/config.py
+++ b/util/config.py
@@ -73,6 +73,7 @@ class Config(object):
 # Note: Must name all valid config items.
 config = Config(environment=None,
                 resource_primary=[],
+                resource_trigger_pol=[],
                 resource_replica=None,
                 resource_research=None,
                 resource_vault=None,


### PR DESCRIPTION
If accepted, please also merge into release-1.7 branch
----

This adds a configuration option resource_trigger_pol to match
resources where data object modifications should trigger policies,
so that policies can be enabled on resources other than the primary
resource.

This change also fixes the situation that not configuring a replication
resource will have a side effect of disabling revision and metadata import
policies.