### PR TITLE
Fix YDA-4331: publication terms order

### DIFF
--- a/vault.py
+++ b/vault.py
@@ -551,7 +551,7 @@ def api_vault_get_publication_terms(ctx):
     terms = ""
 
     iter = genquery.row_iterator(
-        "DATA_NAME, order_desc(DATA_MODIFY_TIME)",
+        "DATA_NAME, order_asc(DATA_MODIFY_TIME)",
         "COLL_NAME = '{}'".format(terms_collection),
         genquery.AS_LIST, ctx)
 


### PR DESCRIPTION
api_vault_get_publication_terms should return the newest rather than
the oldest publication terms, since the newest file has the current terms.

flake8 lint warnings in are caused by earlier unrelated change in dev branch. 

If accepted, please also merge into release-1.7 branch.