### PR TITLE
YDA-4419: fix intake2vault > 32 MB

### DIFF
--- a/yc2Vault.r
+++ b/yc2Vault.r
@@ -1,0 +1,388 @@
+# \file
+# \brief move selected datasets from intake area to the vault area
+#        this rule is to be executed by a background process with write access to vault
+#			and read access to the intake area
+# \author Ton Smeele
+# \copyright Copyright (c) 2015, Utrecht university. All rights reserved
+# \license GPLv3, see LICENSE
+#
+#test {
+#	*intakeRoot = '/nluu1ot/home/grp-intake-youth';
+#	*vaultRoot = '/nluu1ot/home/grp-vault-youth';
+#	uuYc2Vault(*intakeRoot, *vaultRoot, *status);
+#	writeLine("serverLog","result status of yc2Vault is *status");
+#}
+
+
+# \brief
+#
+# \param[in] path  pathname of the tree-item
+# \param[in] name  segment of path, name of collection or data object
+# \param[in] isCol  true if the object is a collection, otherwise false
+# \param[in,out] buffer
+#
+#uuTreeMyRule(*parent, *objectName, *isCol, *buffer) {
+#	writeLine("serverLog","parent      = *parent");
+#	writeLine("serverLog","name        = *objectName");
+#	writeLine("serverLog","isCol       = *isCol");
+#	writeLine("serverLog","buffer[path]= " ++ *buffer."path");
+#	if (*isCol) {
+#	   *buffer."path" = *buffer."path"++"=";
+#	}
+#}
+
+
+
+
+uuYcVaultDatasetGetPath(*vaultRoot, *datasetId, *datasetPath) {
+	uuYcDatasetParseId(*datasetId, *datasetComponents);
+	*wave = *datasetComponents."wave";
+	*experimentType = *datasetComponents."experiment_type";
+	*pseudocode = *datasetComponents."pseudocode";
+	*version = *datasetComponents."version";
+	*sep = "_"; 
+	*wepv = *wave ++ *sep ++ *experimentType ++ *sep ++ *pseudocode ++ *sep ++ "ver*version";
+   *datasetPath = "*vaultRoot/*wave/*experimentType/*pseudocode/*wepv";
+}
+
+uuYcVaultDatasetExists(*vaultRoot, *datasetId, *exists) {
+	*exists = false;
+	uuYcVaultDatasetGetPath(*vaultRoot, *datasetId, *datasetPath);
+	foreach (*row in SELECT COLL_NAME WHERE COLL_NAME = '*datasetPath') {
+		*exists = true;
+		break;
+	}
+}
+
+
+uuYcVaultDatasetAddMeta(*vaultPath, *datasetId) {
+	uuYcDatasetParseId(*datasetId, *datasetComponents);
+	*wave = *datasetComponents."wave";
+	*experimentType = *datasetComponents."experiment_type";
+	*pseudocode = *datasetComponents."pseudocode";
+	*version = *datasetComponents."version";
+	msiGetIcatTime(*date, "unix");
+	msiAddKeyVal(*kv, "wave", *wave);
+	msiAddKeyVal(*kv, "experiment_type", *experimentType);
+	msiAddKeyVal(*kv, "pseudocode", *pseudocode);
+	msiAddKeyVal(*kv, "version", *version);
+	msiAddKeyVal(*kv, "dataset_date_created", *date);
+	msiAssociateKeyValuePairsToObj(*kv, *vaultPath, "-C");
+}
+
+uuYcVaultWalkRemoveObject(*itemParent, *itemName, *itemIsCollection, *buffer, *status) {
+#	writeLine("serverLog", "...removing *itemParent/*itemName");
+	if (*itemIsCollection) {
+		msiRmColl("*itemParent/*itemName", "forceFlag=", *status);
+	} else {
+		msiDataObjUnlink("objPath=*itemParent/*itemName++++forceFlag=", *status);
+	}
+}
+
+
+uuYcVaultIngestObject(*objectPath, *isCollection, *vaultPath, *status) {
+	# from the original object only the below list '*copiedMetadata' of metadata keys 
+	# is copied to the vault object, other info is ignored
+	*copiedMetadata = list("wave", "experiment_type", "pseudocode", "version",
+									 "error", "warning", "comment", "dataset_error",
+									 "dataset_warning", "datasetid");
+	*status = 0;
+	if (*isCollection) {
+		msiCollCreate(*vaultPath, "1", *status);
+		if (*status == 0) {
+			foreach (*row in SELECT META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE
+								WHERE COLL_NAME = '*objectPath'
+			) {
+				msiGetValByKey(*row, "META_COLL_ATTR_NAME", *key);
+				msiGetValByKey(*row, "META_COLL_ATTR_VALUE", *value);
+				msiString2KeyValPair("*key=*value",*kv);
+				# add relevant kvlist to vault collection object
+				foreach (*meta in *copiedMetadata) {
+					if (*key == *meta) {
+						msiAssociateKeyValuePairsToObj(*kv, *vaultPath, "-C");
+					}
+				}
+			}
+			foreach (*row in SELECT COLL_OWNER_NAME, COLL_OWNER_ZONE, COLL_CREATE_TIME
+								WHERE COLL_NAME = '*objectPath'
+			) {
+				msiGetValByKey(*row, "COLL_OWNER_NAME", *ownerName);
+				msiGetValByKey(*row, "COLL_OWNER_ZONE", *ownerZone);
+				msiGetValByKey(*row, "COLL_CREATE_TIME", *createTime);
+				msiString2KeyValPair("submitted_by=*ownerName#*ownerZone",*kvSubmittedBy);
+				msiString2KeyValPair("submitted_date=*createTime",*kvSubmittedDate);
+				msiAssociateKeyValuePairsToObj(*kvSubmittedBy, *vaultPath, "-C");
+				msiAssociateKeyValuePairsToObj(*kvSubmittedDate, *vaultPath, "-C");
+			}
+		}
+	} else {   # its not a collection but a data object
+		# first chksum the orginal file then use it to verify the vault copy
+		msiDataObjChksum(*objectPath, "forceChksum=", *checksum);
+		msiDataObjCopy(*objectPath, *vaultPath, "verifyChksum=", *status);
+		if (*status == 0) {
+			uuChopPath(*objectPath, *collection, *dataName);
+			foreach (*row in SELECT META_DATA_ATTR_NAME, META_DATA_ATTR_VALUE
+								      WHERE COLL_NAME = '*collection'
+								        AND DATA_NAME = '*dataName'
+			) {
+				msiGetValByKey(*row, "META_DATA_ATTR_NAME", *key);
+				msiGetValByKey(*row, "META_DATA_ATTR_VALUE", *value);
+				# add relevant kvlist to vault collection object
+				msiString2KeyValPair("*key=*value",*kv);
+				foreach (*meta in *copiedMetadata) {
+					if (*key == *meta) {
+						msiAssociateKeyValuePairsToObj(*kv, *vaultPath, "-d");
+					}
+				}
+			}
+			# add metadata found in system info
+			foreach (*row in SELECT DATA_OWNER_NAME, DATA_OWNER_ZONE, DATA_CREATE_TIME
+				                  WHERE COLL_NAME = '*collection'
+				                    AND DATA_NAME = '*dataName'
+			) {
+				msiGetValByKey(*row, "DATA_OWNER_NAME", *ownerName);
+				msiGetValByKey(*row, "DATA_OWNER_ZONE", *ownerZone);
+				msiGetValByKey(*row, "DATA_CREATE_TIME", *createTime);
+				msiString2KeyValPair("submitted_by=*ownerName#*ownerZone",*kvSubmittedBy);
+				msiString2KeyValPair("submitted_date=*createTime",*kvSubmittedDate);
+				msiAssociateKeyValuePairsToObj(*kvSubmittedBy, *vaultPath, "-d");
+				msiAssociateKeyValuePairsToObj(*kvSubmittedDate, *vaultPath, "-d");
+				# Skip duplicas
+				break;
+			}
+		}
+	}
+}
+
+
+
+uuYcVaultWalkIngestObject(*itemParent, *itemName, *itemIsCollection, *buffer, *status) {
+	*sourcePath = "*itemParent/*itemName";
+	*destPath = *buffer."destination"; # top level destination is specified 
+	if (*sourcePath != *buffer."source") {
+		# rewrite path to copy objects that are located underneath the toplevel collection
+		*sourceLength = strlen(*sourcePath);
+		*relativePath = substr(*sourcePath, strlen(*buffer."source") + 1, *sourceLength);
+		*destPath = *buffer."destination" ++ "/" ++ *relativePath;
+	}
+#	writeLine("serverLog","VLT from = *sourcePath");
+#	writeLine("serverLog","VLT to   = *destPath");
+	uuYcVaultIngestObject(*sourcePath, *itemIsCollection, *destPath, *status); 
+}
+
+
+uuYcDatasetCollectionMove2Vault(*intakeRoot,*topLevelCollection, *datasetId, *vaultRoot, *status) {
+	writeLine("serverLog","\nmoving dataset-typeA *datasetId from *topLevelCollection to vault");
+	*status = 0;
+	uuYcVaultDatasetExists(*vaultRoot, *datasetId, *exists);
+	if (!*exists) {
+		uuYcVaultDatasetGetPath(*vaultRoot, *datasetId, *vaultPath);
+		# create the in-between levels of the path to the toplevel collection
+		uuChopPath(*vaultPath, *vaultParent, *vaultCollection);
+		msiCollCreate(*vaultParent, "1", *status);		
+#		writeLine("serverLog","VAULT: dataset created *datasetId status=*status path=*vaultPath");
+		if (*status == 0) {
+			# copy the dataset tree to the vault
+			uuChopPath(*topLevelCollection, *intakeParent, *intakeCollection);
+			*buffer."source" = *topLevelCollection;
+			*buffer."destination" = *vaultPath;
+#			writeLine("serverLog","VAULT: source = *topLevelCollection");
+#			writeLine("serverLog","VAULT: dest   = *vaultPath");
+			uuTreeWalk(
+				"forward", 
+				*topLevelCollection,
+				"uuYcVaultWalkIngestObject",
+				*buffer,
+				*status
+				);
+                       uuKvClear(*buffer);
+			if (*status == 0) {
+				# stamp the vault dataset collection with additional metadata
+				msiGetIcatTime(*date, "unix");
+				msiAddKeyVal(*kv, "dataset_date_created", *date);
+				msiAssociateKeyValuePairsToObj(*kv, *vaultPath, "-C");
+				# and finally remove the dataset original in the intake area
+				msiRmColl(*topLevelCollection, "forceFlag=", *error);
+#				uuTreeWalk(
+#					"reverse", 
+#					*topLevelCollection, 
+#					"uuYcVaultWalkRemoveObject", 
+#					*buffer, 
+#					*error
+#					);
+				if (*error != 0) {
+					writeLine("serverLog",
+						"ERROR: unable to remove intake collection *topLevelCollection");
+				}
+			} else {
+				# move failed (partially), cleanup vault
+				# NB: keep the dataset in the vault queue so we can retry some other time
+				writeLine("serverLog","ERROR: Ingest failed for *datasetId error = *status");
+				uuTreeWalk("reverse", *vaultPath, "uuYcVaultWalkRemoveObject", *buffer, *error);
+			}
+
+		}
+	} else {
+		writeLine("serverLog","INFO: version already exists in vault: *datasetId");
+		# duplicate dataset, signal error and throw out of vault queue
+		*message = "Duplicate dataset, version already exists in vault";
+		uuYcDatasetErrorAdd(*intakeRoot, *datasetId,*message);
+		uuYcDatasetMelt(*topLevelCollection, *datasetId, *status);
+		uuYcDatasetUnlock(*topLevelCollection, *datasetId, *status);
+		*status = 1; # duplicate dataset version error
+	}
+}
+
+uuYcDatasetObjectsOnlyMove2Vault(*intakeRoot, *topLevelCollection, *datasetId, *vaultRoot, *status) {
+	writeLine("serverLog","\nmoving dataset-typeB *datasetId from *topLevelCollection to vault");
+	uuYcVaultDatasetExists(*vaultRoot, *datasetId, *exists);
+	if (!*exists) {
+		# new dataset(version) we can safely ingest into vault
+		uuYcVaultDatasetGetPath(*vaultRoot, *datasetId, *vaultPath);
+		# create path to and including the toplevel collection (will create in-between levels)
+		msiCollCreate(*vaultPath, "1", *status);
+#		writeLine("serverLog","VAULT: dataset created *datasetId status=*status path=*vaultPath");
+		if (*status == 0) {
+			# stamp the vault dataset collection with default metadata
+			uuYcVaultDatasetAddMeta(*vaultPath, *datasetId);
+			# copy data objects to the vault
+			foreach (*dataRow in SELECT DATA_NAME
+						WHERE COLL_NAME = '*topLevelCollection'
+						  AND META_DATA_ATTR_NAME = 'dataset_toplevel'
+						  AND META_DATA_ATTR_VALUE = '*datasetId'
+				) {
+				msiGetValByKey(*dataRow, "DATA_NAME", *dataName);
+				*intakePath = "*topLevelCollection/*dataName";
+				uuYcVaultIngestObject(*intakePath, false, "*vaultPath/*dataName", *status);
+				if (*status != 0) {
+					break;
+				}
+			}
+			if (*status == 0) {
+				# data ingested, what's left is to delete the original in intake area
+				# this will also melt/unfreeze etc because metadata is removed too
+				foreach (*dataRow in SELECT DATA_NAME
+						WHERE COLL_NAME = '*topLevelCollection'
+						  AND META_DATA_ATTR_NAME = 'dataset_toplevel'
+						  AND META_DATA_ATTR_VALUE = '*datasetId'
+				) {
+					msiGetValByKey(*dataRow, "DATA_NAME", *dataName);
+					*intakePath = "*topLevelCollection/*dataName";
+#					writeLine("serverLog","removing intake file: *intakePath");
+					msiDataObjUnlink("objPath=*intakePath++++forceFlag=", *error);
+					if (*error != 0) {
+						writeLine("serverLog","ERROR: unable to remove intake object *intakePath");
+					}
+				}
+			} else {
+				# error occurred during ingest, cleanup vault area and relay the error to user
+				# NB: keep the dataset in the vault queue so we can retry some other time
+				writeLine("serverLog","ERROR: Ingest failed for *datasetId error = *status");
+				*buffer = "required yet dummy parameter";
+				uuTreeWalk("reverse", *vaultPath, "uuYcVaultWalkRemoveObject", *buffer, *error);
+			}
+		}
+	} else {
+		# duplicate dataset, signal error and throw out of vault queue
+		writeLine("serverLog","INFO: version already exists in vault: *datasetId");
+		*message = "Duplicate dataset, version already exists in vault";
+		uuYcDatasetErrorAdd(*intakeRoot, *datasetId,*message);
+		uuYcDatasetMelt(*topLevelCollection, *datasetId, *status);
+		uuYcDatasetUnlock(*topLevelCollection, *datasetId, *status);
+		*status = 1; # duplicate dataset version error
+	}
+}
+
+
+
+# \brief move all locked datasets to the vault
+#
+# \param[in]  intakeCollection  pathname root of intake area
+# \param[in]  vaultCollection   pathname root of vault area
+# \param[out] status            result of operation either "ok" or "error"
+#
+uuYc2Vault(*intakeRoot, *vaultRoot, *status) {
+	# 1. add to_vault_freeze metadata lock to the dataset
+	# 2. check that dataset does not yet exist in the vault
+	# 3. copy dataset to vault with its metadata
+	# 4. remove dataset from intake
+	# upon any error:
+	# - delete partial data from vault
+	# - add error to intake dataset metadata
+	# - remove locks on intake dataset (to_vault_freeze, to_vault_lock)
+	*status = 0; # 0 is success, nonzero is error
+	*datasets_moved = 0;
+
+	# note that we have to allow for multiple types of datasets:
+	#    type A: a single toplevel collection with a tree underneath
+	#    type B: one or more datafiles located within the same collection
+	# processing varies slightly between them, so process each type in turn
+	#
+	# TYPE A:
+	foreach (*row in SELECT COLL_NAME, META_COLL_ATTR_VALUE
+				WHERE META_COLL_ATTR_NAME = 'dataset_toplevel'
+				  AND COLL_NAME like '*intakeRoot/%') {
+		msiGetValByKey(*row, "COLL_NAME", *topLevelCollection);
+		msiGetValByKey(*row, "META_COLL_ATTR_VALUE", *datasetId);
+		uuYcObjectIsLocked(*topLevelCollection, true, *locked, *frozen);
+		if (*locked) {
+			uuYcDatasetFreeze(*topLevelCollection, *datasetId, *status);
+			if (*status == 0) {
+				# datset frozen, now move to fault and remove from intake area
+				uuYcDatasetCollectionMove2Vault(
+						*intakeRoot, 
+						*topLevelCollection,
+						*datasetId,
+						*vaultRoot,
+						*status
+						);
+				if (*status == 0) {
+					*datasets_moved = *datasets_moved + 1;
+				}
+			}
+		}
+	}
+	# TYPE B:
+	foreach (*row in SELECT COLL_NAME, META_DATA_ATTR_VALUE
+				WHERE META_DATA_ATTR_NAME = 'dataset_toplevel'
+				  AND COLL_NAME like '*intakeRoot%'
+# fixme: skip collnames that are not in the same tree yet share the prefix
+				) {
+
+		msiGetValByKey(*row, "COLL_NAME", *topLevelCollection);
+		msiGetValByKey(*row, "META_DATA_ATTR_VALUE", *datasetId);
+		# check if to_vault_lock exists on all the dataobjects of this dataset
+		*allLocked = true;
+		foreach (*dataRow in SELECT DATA_NAME
+						WHERE COLL_NAME = '*topLevelCollection'
+						  AND META_DATA_ATTR_NAME = 'dataset_toplevel'
+						  AND META_DATA_ATTR_VALUE = '*datasetId'
+			) {
+			msiGetValByKey(*dataRow, "DATA_NAME", *dataName);
+			uuYcObjectIsLocked("*topLevelCollection/*dataName", false, *locked, *frozen);
+			*allLocked = *allLocked && *locked;
+		}
+		if (*allLocked) {
+			uuYcDatasetFreeze(*topLevelCollection, *datasetId, *status);
+			if (*status == 0) {
+				# dataset frozen, now move to fault and remove from intake area
+				uuYcDatasetObjectsOnlyMove2Vault(
+					*intakeRoot,
+					*topLevelCollection,
+					*datasetId,
+					*vaultRoot,
+					*status
+					);
+				if (*status == 0) {
+					*datasets_moved = *datasets_moved + 1;
+				}
+			}
+		}
+	}
+	if (*datasets_moved > 0) {
+		writeLine("serverLog","\nmoved in total *datasets_moved dataset(s) to the vault");
+	}
+}
+
+#input null
+#output ruleExecOut

--- a/ycDataset.r
+++ b/ycDataset.r
@@ -1,0 +1,175 @@
+# \file
+# \brief     Youth Cohort - Dataset related functions.
+# \author    Chris Smeele
+# \copyright Copyright (c) 2015, Utrecht University. All rights reserved.
+# \license   GPLv3, see LICENSE
+
+# \brief Generate a dataset identifier based on WEPV values.
+#
+# \param[in]  idComponents a kvList containing WEPV values
+# \param[out] id a dataset id string
+#
+uuYcDatasetMakeId(*idComponents, *id){
+	*id =
+		           *idComponents."wave"
+		++ "\t" ++ *idComponents."experiment_type"
+		++ "\t" ++ *idComponents."pseudocode"
+		++ "\t" ++ *idComponents."version"
+		++ "\t" ++ *idComponents."directory";
+}
+
+# \brief Parse a dataset identifier and return WEPV values.
+#
+# \param[in]  id a dataset id string
+# \param[out] idComponents a kvList containing WEPV values
+#
+uuYcDatasetParseId(*id, *idComponents){
+	*idParts = split(*id, "\t");
+	*idComponents."wave"            = elem(*idParts, 0);
+	*idComponents."experiment_type" = elem(*idParts, 1);
+	*idComponents."pseudocode"      = elem(*idParts, 2);
+	*idComponents."version"         = elem(*idParts, 3);
+	*idComponents."directory"       = elem(*idParts, 4);
+}
+
+# \brief Find dataset ids under *root.
+#
+# \param[in]  root
+# \param[out] ids  a list of dataset ids
+#
+uuYcDatasetGetIds(*root, *ids) {
+	*idsString = "";
+	foreach (*item in SELECT META_DATA_ATTR_VALUE WHERE COLL_NAME = "*root" AND META_DATA_ATTR_NAME = 'dataset_id') {
+		# Datasets directly under *root need to be checked for separately due to limitations on the general query system.
+		if (strlen(*idsString) > 0) {
+			*idsString = *idsString ++ "\n";
+		}
+		*idsString = *idsString ++ *item."META_DATA_ATTR_VALUE";
+	}
+	foreach (*item in SELECT META_DATA_ATTR_VALUE WHERE COLL_NAME LIKE "*root/%" AND META_DATA_ATTR_NAME = 'dataset_id') {
+		if (strlen(*idsString) > 0) {
+			*idsString = *idsString ++ "\n";
+		}
+		*idsString = *idsString ++ *item."META_DATA_ATTR_VALUE";
+	}
+	*ids = split(*idsString, "\n");
+}
+
+# \brief Get a list of toplevel objects that belong to the given dataset id.
+#
+# \param[in]  root
+# \param[in]  id
+# \param[out] objects      a list of toplevel object paths
+# \param[out] isCollection whether this dataset consists of a single toplevel collection
+#
+uuYcDatasetGetToplevelObjects(*root, *id, *objects, *isCollection) {
+	*isCollection = false;
+
+	*objectsString = "";
+	foreach (*item in SELECT COLL_NAME WHERE COLL_NAME LIKE "*root/%" AND META_COLL_ATTR_NAME = 'dataset_toplevel' AND META_COLL_ATTR_VALUE = "*id") {
+		*isCollection = true;
+		*objectsString = *item."COLL_NAME";
+	}
+	if (!*isCollection) {
+		foreach (*item in SELECT DATA_NAME, COLL_NAME WHERE COLL_NAME = "*root" AND META_DATA_ATTR_NAME = 'dataset_toplevel' AND META_DATA_ATTR_VALUE = "*id") {
+			# Datasets directly under *root need to be checked for separately due to limitations on the general query system.
+			if (strlen(*objectsString) > 0) {
+				*objectsString = *objectsString ++ "\n";
+			}
+			*objectsString = *objectsString ++ *item."COLL_NAME" ++ "/" ++ *item."DATA_NAME";
+		}
+		foreach (*item in SELECT DATA_NAME, COLL_NAME WHERE COLL_NAME LIKE "*root/%" AND META_DATA_ATTR_NAME = 'dataset_toplevel' AND META_DATA_ATTR_VALUE = "*id") {
+			if (strlen(*objectsString) > 0) {
+				*objectsString = *objectsString ++ "\n";
+			}
+			*objectsString = *objectsString ++ *item."COLL_NAME" ++ "/" ++ *item."DATA_NAME";
+		}
+	}
+	*objects = split(*objectsString, "\n");
+	#writeLine("stdout", "Got dataset toplevel objects for <*id>: *objectsString");
+}
+
+# \brief Get a list of relative paths to all data objects in a dataset.
+#
+# \param[in]  root
+# \param[in]  id
+# \param[out] objects a list of relative object paths (e.g. file1.dat, some-subdir/file2.dat...)
+#
+uuYcDatasetGetDataObjectRelPaths(*root, *id, *objects) {
+
+	uuYcDatasetGetToplevelObjects(*root, *id, *toplevelObjects, *isCollection);
+
+	# NOTE: This will crash when an invalid dataset id is provided.
+	if (*isCollection) {
+		*parentCollection = elem(*toplevelObjects, 0);
+	} else {
+		uuChopPath(elem(*toplevelObjects, 0), *dataObjectParent, *dataObjectName);
+		*parentCollection = *dataObjectParent;
+	}
+
+	*objectsString = "";
+	foreach (*item in SELECT DATA_NAME, COLL_NAME WHERE COLL_NAME = "*parentCollection" AND META_DATA_ATTR_NAME = 'dataset_id' AND META_DATA_ATTR_VALUE = "*id") {
+		# Datasets directly under *root need to be checked for separately due to limitations on the general query system.
+		if (strlen(*objectsString) > 0) {
+			*objectsString = *objectsString ++ "\n";
+		}
+		*objectsString = *objectsString ++ *item."DATA_NAME";
+	}
+	foreach (*item in SELECT DATA_NAME, COLL_NAME WHERE COLL_NAME LIKE "*parentCollection/%" AND META_DATA_ATTR_NAME = 'dataset_id' AND META_DATA_ATTR_VALUE = "*id") {
+		if (strlen(*objectsString) > 0) {
+			*objectsString = *objectsString ++ "\n";
+		}
+		*objectsString = *objectsString
+			++ substr(*item."COLL_NAME", strlen(*parentCollection)+1, strlen(*item."COLL_NAME"))
+			++ "/"
+			++ *item."DATA_NAME";
+	}
+	*objects = split(*objectsString, "\n");
+}
+
+# \brief Check if a dataset id is locked.
+#
+# \param[in]  root
+# \param[in]  id
+# \param[out] isLocked
+# \param[out] isFrozen
+#
+uuYcDatasetIsLocked(*root, *id, *isLocked, *isFrozen) {
+	uuYcDatasetGetToplevelObjects(*root, *id, *toplevelObjects, *isCollection);
+
+	*isLocked = false;
+	*isFrozen = false;
+	foreach (*item in *toplevelObjects) {
+		uuYcObjectIsLocked(*item, *isCollection, *isLocked, *isFrozen);
+		if (*isLocked || *isFrozen) {
+			break;
+		}
+	}
+}
+
+
+# \brief Adds an error to the dataset specified by *datasetId.
+#
+# \param[in] root
+# \param[in] datasetId
+# \param[in] message
+#
+uuYcDatasetErrorAdd(*root, *datasetId, *message) {
+
+	uuYcDatasetGetToplevelObjects(*root, *datasetId, *toplevelObjects, *isCollection);
+
+	foreach (*toplevel in *toplevelObjects) {
+		msiAddKeyVal(*kv, "dataset_error", "*message");
+		# note that we want to silently ignore any duplicates of the message (using errorcode)
+		errorcode(msiAssociateKeyValuePairsToObj(*kv, *toplevel, if *isCollection then "-C" else "-d"));
+
+		# This does not work for some reason.
+		#uuSetMetaData(
+		#	*toplevel,
+		#	"comment",
+		#	*comment,
+		#	if *isCollection then "-C" else "-d"
+		#);
+	}
+}
+

--- a/ycDatasetGetToplevel.r
+++ b/ycDatasetGetToplevel.r
@@ -1,0 +1,76 @@
+# \file
+# \brief dataset lookup function
+# \author Ton Smeele
+# \copyright Copyright (c) 2015, Utrecht university. All rights reserved
+# \license GPLv3, see LICENSE
+#
+
+#test {
+#	uuYcDatasetGetTopLevel("/tsm/home/rods", "x", *collection, *isCol);
+#	writeLine("stdout","coll = *collection  and isCol = *isCol");
+#}
+
+
+# \brief uuYcDatasetGetTopLevel  retrieves the collection path and dataset type for a dataset
+#
+# \param[in]   rootcollection       path of a tree to search for the dataset
+# \param[in]	datasetid            unique identifier of the dataset
+# \param[out]  topLevelCollection   collection that has the dataset
+#                                   if dataset is not found an empty string is returned
+# \param[out]  topLevelIsCollection type of dataset: true = collection false = data objects
+#
+uuYcDatasetGetTopLevel(*rootCollection, *datasetId, *topLevelCollection, *topLevelIsCollection) {
+	# datasets can be
+	#  A) one collection with a subtree
+	#  B) one or more data objects located (possibly with other objects) in same collection
+	*topLevelIsCollection = false;
+	*topLevelCollection = "";
+	# try to find a collection. note we will expect 0 or 1 rows:
+	foreach (*row in SELECT COLL_NAME
+					WHERE META_COLL_ATTR_NAME = 'dataset_toplevel'
+					  AND META_COLL_ATTR_VALUE = '*datasetId'
+					  AND COLL_NAME LIKE '*rootCollection/%'
+				) {
+		*topLevelIsCollection = true;
+		msiGetValByKey(*row, "COLL_NAME", *topLevelCollection);
+	}
+	if (! *topLevelIsCollection) {
+		# also try the root itself
+		foreach (*row in SELECT COLL_NAME
+						WHERE META_COLL_ATTR_NAME = 'dataset_toplevel'
+						  AND META_COLL_ATTR_VALUE = '*datasetId'
+						  AND COLL_NAME = '*rootCollection'
+					) {
+			*topLevelIsCollection = true;
+			msiGetValByKey(*row, "COLL_NAME", *topLevelCollection);
+		}
+	}
+	if (! *topLevelIsCollection) {
+		# apparently not a collection, let's search for data objects instead
+		foreach (*row in SELECT COLL_NAME,DATA_NAME
+					WHERE META_DATA_ATTR_NAME = 'dataset_toplevel'
+					  AND META_DATA_ATTR_VALUE = '*datasetId'
+					  AND COLL_NAME LIKE '*rootCollection/%'
+				) {
+			msiGetValByKey(*row, "COLL_NAME", *topLevelCollection);
+			break;
+		}
+		if (*topLevelCollection == "") {
+			# not found yet, maybe data object(s) in the rootcollection itself?
+
+			foreach (*row in SELECT COLL_NAME,DATA_NAME
+						WHERE META_DATA_ATTR_NAME = 'dataset_toplevel'
+						  AND META_DATA_ATTR_VALUE = '*datasetId'
+						  AND COLL_NAME = '*rootCollection'
+					) {
+				msiGetValByKey(*row, "COLL_NAME", *topLevelCollection);
+				break;
+			}
+		} else {
+			#  dataset not found!
+		}
+	}
+}
+
+#input null
+#output ruleExecOut

--- a/ycDatasetLock.r
+++ b/ycDatasetLock.r
@@ -1,0 +1,253 @@
+# \file
+# \brief lock/freeze and unlock/unfreeze datasets within a collection
+# \author Ton Smeele
+# \copyright Copyright (c) 2015, Utrecht university. All rights reserved
+# \license GPLv3, see LICENSE
+#
+
+#test {
+#*collection = "/nluu1ot/home/ton";
+#*datasetId = "y";
+#uuYcDatasetLock(*collection, *datasetId, *result);
+#writeLine("stdout","lock result = *result");
+#uuYcDatasetFreeze(*collection, *datasetId, *result);
+#writeLine("stdout","freeze result = *result");
+#uuYcObjectIsLocked("*collection/Newfile.txt",false, *locked, *frozen);
+#writeLine("stdout","locked = *locked  and frozen = *frozen");
+
+#uuYcDatasetUnlock(*collection, *datasetId, *result);
+#writeLine("stdout","unlock result = *result");
+#uuYcDatasetMelt(*collection, *datasetId, *result);
+#writeLine("stdout","melt result = *result");
+#uuYcDatasetUnlock(*collection, *datasetId, *result);
+#writeLine("stdout","unlock result = *result");
+#}
+
+uuYcDatasetLockChangeObject(*parentCollection, *objectName, *isCollection,
+						 *lockName, *lockIt, *dateTime,*result) {
+	*objectType = "-d";
+	*path = "*parentCollection/*objectName";
+	if (*isCollection) {
+		*objectType = "-C";
+		*collection = *objectName;
+	}
+	if (*lockIt) {
+		msiString2KeyValPair("*lockName=*dateTime",*kvPair);
+		*result = errorcode(msiSetKeyValuePairsToObj(*kvPair, *path, *objectType));
+	} else {  # unlock it
+		#
+		# if the lock is of type to_vault_lock this operation is
+		# disallowed if the object also has a to_vault_freeze lock
+		uuYcObjectIsLocked(*path,*isCollection,*locked,*frozen);
+		*allowed = (*lockName == "to_vault_freeze") || !*frozen;
+		if (*allowed) {
+			*result = 0;
+			# in order to remove the key we need to lookup its value(s)
+			if (*isCollection) {
+				# remove lock from collection
+				foreach (*row in SELECT META_COLL_ATTR_VALUE
+									WHERE COLL_NAME = '*path'
+									  AND META_COLL_ATTR_NAME = '*lockName') {
+					msiGetValByKey(*row, "META_COLL_ATTR_VALUE", *value);
+					msiString2KeyValPair("*lockName=*value", *kvPair);
+					*result = errorcode(
+								msiRemoveKeyValuePairsFromObj(*kvPair, *path, "-C")
+								);
+					if (*result != 0) {
+						break;
+					}
+				}
+			} else {
+				# remove lock from data object
+				foreach (*row in SELECT META_DATA_ATTR_VALUE
+								WHERE DATA_NAME = '*objectName'
+								  AND COLL_NAME = '*parentCollection'
+								  AND META_DATA_ATTR_NAME = '*lockName'
+					) {
+					msiGetValByKey(*row,"META_DATA_ATTR_VALUE",*value);
+					msiString2KeyValPair("*lockName=*value",*kvPair);
+					*result = errorcode(
+								msiRemoveKeyValuePairsFromObj(
+										*kvPair,
+										"*parentCollection/*objectName",
+										"-d"
+									)
+								);
+					if (*result != 0) {
+						break;
+					}
+				}
+			} # end else remove lock from dataobject
+		} else { # unlock not allowed
+			*result = -1;
+		}
+	}
+}
+
+uuYcDatasetWalkVaultLock(*itemCollection, *itemName, *itemIsCollection, *buffer, *error) {
+	msiGetIcatTime(*dateTime,"unix");
+	uuYcDatasetLockChangeObject(*itemCollection, *itemName, *itemIsCollection,
+						 "to_vault_lock", true, *dateTime, *error);
+}
+
+uuYcDatasetWalkVaultUnlock(*itemCollection, *itemName, *itemIsCollection, *buffer, *error) {
+	msiGetIcatTime(*dateTime,"unix");
+	uuYcDatasetLockChangeObject(*itemCollection, *itemName, *itemIsCollection,
+						 "to_vault_lock", false, *dateTime, *error);
+}
+
+uuYcDatasetWalkFreezeLock(*itemCollection, *itemName, *itemIsCollection, *buffer, *error) {
+	msiGetIcatTime(*dateTime,"unix");
+	uuYcDatasetLockChangeObject(*itemCollection, *itemName, *itemIsCollection,
+						 "to_vault_freeze", true, *dateTime, *error);
+}
+
+
+uuYcDatasetWalkFreezeUnlock(*itemCollection, *itemName, *itemIsCollection, *buffer, *error) {
+	msiGetIcatTime(*dateTime,"unix");
+	uuYcDatasetLockChangeObject(*itemCollection, *itemName, *itemIsCollection,
+						 "to_vault_freeze", false, *dateTime, *error);
+}
+
+
+uuYcDatasetLockChange(*rootCollection, *datasetId, *lockName, *lockIt, *status){
+   *status = -1;
+	*lock = "Unlock";
+	if (*lockIt) {
+		*lock = "Lock";
+	}
+	*lockProcedure = "Vault";
+	if (*lockName == "to_vault_freeze") {
+		*lockProcedure = "Freeze";
+	}
+	# find the toplevel collection for this dataset
+	uuYcDatasetGetTopLevel(*rootCollection, *datasetId, *collection, *isCollection);
+	if (*collection != "") {
+		# we found the dataset, now change the lock on each object
+		if (*isCollection) {
+			*buffer = "dummy";
+			uuTreeWalk("forward", *collection, "uuYcDatasetWalk*lockProcedure*lock", *buffer, *error);
+			*status = *error;
+#			if (*error == "0") {
+#				*status = 0;
+#			}
+		} else {
+			# dataset is not a collection, let's find the objects and make the change
+			msiGetIcatTime(*dateTime,"unix");
+			*status = 0;
+			foreach (*row in SELECT DATA_NAME
+						WHERE COLL_NAME = '*collection'
+						  AND META_DATA_ATTR_NAME = 'dataset_toplevel'
+						  AND META_DATA_ATTR_VALUE = '*datasetId'
+				) {
+				msiGetValByKey(*row,"DATA_NAME",*dataName);
+				# now change it ....
+				uuYcDatasetLockChangeObject(
+							*collection,
+							*dataName,
+							false,
+							*lockName,
+							*lockIt,
+							*dateTime,
+							*error);
+				if (*error != 0 ) {
+					*status = *error;
+					break;
+				}
+			}
+		}
+
+	} else {
+		# result is false "dataset not found"
+	}
+}
+
+
+# \brief uuYcDatasetLock locks (all objects of) a dataset
+#
+# \param[in]  collection collection that may have datasets
+# \param[in]  datasetId  identifier to depict the dataset
+# \param[out] status     0 upon success, otherwise nonzero
+#
+uuYcDatasetLock(*collection, *datasetId, *status) {
+	uuYcDatasetLockChange(*collection, *datasetId,"to_vault_lock", true, *status);
+}
+
+# \brief uuYcDatasetUnlock  unlocks (all objects of) a dataset
+#
+# \param[in]  collection collection that may have datasets
+# \param[in]  datasetId  identifier to depict the dataset
+# \param[out] result     "true" upon success, otherwise "false"
+# \param[out] status     0 upon success, otherwise nonzero
+#
+uuYcDatasetUnlock(*collection, *datasetId, *status) {
+	uuYcDatasetLockChange(*collection, *datasetId, "to_vault_lock", false, *status);
+}
+
+# \brief uuYcDatasetFreeze  freeze-locks (all objects of) a dataset
+#
+# \param[in]  collection collection that may have datasets
+# \param[in]  datasetId  identifier to depict the dataset
+# \param[out] status     0 upon success, otherwise nonzero
+#
+uuYcDatasetFreeze(*collection, *datasetId, *status) {
+	uuYcDatasetLockChange(*collection, *datasetId,"to_vault_freeze", true, *status);
+}
+
+# \brief uuYcDatasetUnfreeze  undo freeze-locks (all objects of) a dataset
+#
+# \param[in]  collection collection that may have datasets
+# \param[in]  datasetId  identifier to depict the dataset
+# \param[out] status     0 upon success, otherwise nonzero
+#
+uuYcDatasetMelt(*collection, *datasetId, *status) {
+	uuYcDatasetLockChange(*collection, *datasetId, "to_vault_freeze", false, *status);
+}
+
+# \brief uuYcObjectIsLocked  query an object to see if it is locked
+#
+# \param[in]  objectPath    full path to collection of data object
+# \param[in]  isCollection  true if path references a collection
+# \param[out] locked        true if the object is vault-locked
+# \param[out] frozen        true if the object is vault-frozen
+
+uuYcObjectIsLocked(*objectPath, *isCollection, *locked, *frozen) {
+	*locked = false;
+	*frozen = false;
+	if (*isCollection) {
+		foreach (*row in SELECT META_COLL_ATTR_NAME
+					WHERE COLL_NAME = '*objectPath'
+					) {
+			msiGetValByKey(*row, "META_COLL_ATTR_NAME", *key);
+			if (   *key == "to_vault_lock"
+				 || *key == "to_vault_freeze"
+				 ) {
+				*locked = true;
+				if (*key == "to_vault_freeze") {
+					*frozen = true;
+					break;
+				}
+			}
+		}
+	} else {
+		uuChopPath(*objectPath, *parentCollection, *dataName);
+		foreach (*row in SELECT META_DATA_ATTR_NAME
+					WHERE COLL_NAME = '*parentCollection'
+					  AND DATA_NAME = '*dataName'
+			) {
+			msiGetValByKey(*row, "META_DATA_ATTR_NAME", *key);
+			if (   *key == "to_vault_lock"
+				 || *key == "to_vault_freeze"
+				 ) {
+				*locked = true;
+				if (*key == "to_vault_freeze") {
+					*frozen = true;
+					break;
+				}
+			}
+		}
+	}
+}
+
+#input null
+#output ruleExecOut

--- a/ycModule.r
+++ b/ycModule.r
@@ -4,18 +4,6 @@
 # \license   GPLv3, see LICENSE
 
 
-# \brief move all locked datasets to the vault
-#
-# \param[in]  intakeCollection  pathname root of intake area
-# \param[in]  vaultCollection   pathname root of vault area
-# \param[out] status            result of operation either "ok" or "error"
-#
-uuYc2Vault(*intakeRoot, *vaultRoot, *status) {
-    *status = 0;
-    rule_intake_to_vault(*intakeRoot, *vaultRoot);
-}
-
-
 # \brief (over)write data object with a list of vault object checksums
 #
 # \param[in]  vaultRoot          root collection to be indexed

--- a/ycUtil.r
+++ b/ycUtil.r
@@ -1,0 +1,36 @@
+# Youth cohort utility functions
+
+# \brief Clears a kv-list's contents.
+#
+# \param kvList
+#
+uuKvClear(*kvList) {
+        *kvList."." = ".";
+        foreach (*key in *kvList) {
+                *kvList.*key = ".";
+        }
+}
+
+uuYcObjectIsLocked(*objPath, *locked) {
+        msiGetObjType(*objPath, *objType);
+        *locked = false;
+        if (*objType == '-d') {
+                uuChopPath(*objPath, *collection, *dataName);
+                foreach (*row in SELECT META_DATA_ATTR_VALUE
+                                        WHERE COLL_NAME = '*collection'
+                                          AND DATA_NAME = '*dataName'
+                                          AND META_DATA_ATTR_NAME = 'to_vault_lock'
+                        ) {
+                        *locked = true;
+                        break;
+                }
+        } else {
+                foreach (*row in SELECT META_COLL_ATTR_VALUE
+                                        WHERE COLL_NAME = '*objPath'
+                                          AND META_COLL_ATTR_NAME = 'to_vault_lock'
+                        ) {
+                        *locked = true;
+                        break;
+                }
+        }
+}


### PR DESCRIPTION
Restore iRODS legacy rule language code for
copying data objects from intake to vault from Yoda 1.6. The original
Python code in Yoda 1.7 is unable to handle files larger
than 32 MB, because of a PREP issue:
https://github.com/irods/irods_rule_engine_plugin_python/issues/54

If accepted, please cherry-pick to release-1.7 and release-1.8 branches as well.