### PR TITLE
Fix YDA-4542 landing page fail on empty geobox

### DIFF
--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -171,6 +171,7 @@
                                 <label>Geolocation</label>
                             </div>
                             <div class="col-sm-10">
+                            {% if loc.geoLocationBox and loc.geoLocationBox | length >= 4 %}
                                 <span>
                                         <div class='map' id='map{{ loop.index }}'></div>
                                                 <script>
@@ -196,6 +197,7 @@
                 }
                                                 </script>
                                     </span>
+                            {% endif %}
                                 <span>
                                 {% if loc.Description_Temporal %}
                                     {{ loc.Description_Temporal.Start_Date }} - {{ loc.Description_Temporal.End_Date }} |


### PR DESCRIPTION
This makes landing page generation work if the user has entered
a location with an empty geoLocationBox.

If accepted, please cherry-pick to release-1.7 and release-1.8 branches as well.