### PR TITLE
Increase lock time to 1 week

### DIFF
--- a/uuLock.r
+++ b/uuLock.r
@@ -111,8 +111,8 @@ uuLockExists(*collection, *isLocked) {
 		msiGetValByKey(*row,"META_COLL_ATTR_VALUE",*lockValue);
 		*lockTime = double(uuLockGetDateTime(*lockValue));
 		if (
-			    ((*lockTime + 5 * 60) < *currentTime)
-					#	remove locks/requests after expire time of 5 minutes
+			    ((*lockTime + 7 * 86400 ) < *currentTime)
+					#	remove locks/requests after expire time of 1 week
 				 	#			 && (*lockKey == "lockRequest")
 			) {
 			# cleanup lock requests older than 5 minutes


### PR DESCRIPTION
This is part of the fix for YDA-4407, which improves locking for the
intake-to-vault job. The main part of the fix is in the Ansible
playbook. We're increasing the lock time so that the lock remains
in place during typical batches, which could take more than 5 minutes
to process, but typically not more than a couple of hours.

If accepted, please merge into release-1.7 and release-1.8 branches as well.