### PR TITLE
Allow for accidental string values in collected monthly storage data AVU

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -89,8 +89,9 @@ def api_resource_full_year_group_data(ctx, group_name):
         for row in iter:
             data = jsonutil.parse(row[0])
             tierName = data[1]
-            total_storage += data[2]
-            data_size = ceil((data[2] / 1000000000000.0) * 10) / 10  # bytes to terabytes
+            monthly_storage = int(data[2])  # historic scripts sometimes used string
+            total_storage += monthly_storage
+            data_size = ceil((monthly_storage / 1000000000000.0) * 10) / 10  # bytes to terabytes
             try:
                 full_year_data[tierName][referenceMonth - 1] = data_size
             except KeyError:


### PR DESCRIPTION
Somehow the scripts we use to fill-in the monthly storage per group via
AVU's on the user-group have sometimes put in string values instead of
integer values. Or so it seems.

This showed up in our Science environment.

irods@lp0023 /etc/irods/yoda-ruleset /nluu6p/home/rods $ iquest --no-page "%s %s %s" "SELECT META_USER_ATTR_VALUE, USER_NAME, META_USER_ATTR_NAME WHERE META_USER_ATTR_NAME LIKE 'org_storage_data_month%' AND USER_NAME LIKE 'research%'" > /tmp/storage-list.txt

irods@lp0023 /etc/irods/yoda-ruleset /nluu6p/home/rods $ grep research-ton /tmp/storage-list.txt | sort
["biochemistry", "Standard", 0] research-ton org_storage_data_month01
["biochemistry", "Standard", 0] research-ton org_storage_data_month02
["biochemistry", "Standard", 0] research-ton org_storage_data_month03
["biochemistry", "Standard", 0] research-ton org_storage_data_month04
["biochemistry", "Standard", 0] research-ton org_storage_data_month05
["biochemistry", "Standard", 0] research-ton org_storage_data_month06
["biochemistry", "Standard", 0] research-ton org_storage_data_month07
["biochemistry", "Standard", 0] research-ton org_storage_data_month08
["biochemistry", "Standard", 0] research-ton org_storage_data_month09
["biochemistry", "Standard", 0] research-ton org_storage_data_month10
["biochemistry","Standard","0"] research-ton org_storage_data_month11
["biochemistry", "Standard", 0] research-ton org_storage_data_month12

And notice month 11 here.

This fixes the following error in rodsLog for these cases:

Aug 23 09:44:42 pid:16441 NOTICE: writeLine: inString = {s.t.snel@uu.nl#nluu6p} Error: API rule <api_resource_full_year_group_data> failed with uncaught error (trace follows below this line)
Traceback (most recent call last):
  File "/etc/irods/rules_uu/util/api.py", line 156, in wrapper
    result = f(ctx, **data)
  File "/etc/irods/rules_uu/resources.py", line 92, in api_resource_full_year_group_data
    total_storage += data[2]
TypeError: unsupported operand type(s) for +=: 'int' and 'str'