### PR TITLE
Fix regression in not logging out during UI testing.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def pytest_bdd_apply_tag(tag, function):
 
 def pytest_bdd_after_scenario(request, feature, scenario):
     """Logout user after scenario when we have a browser."""
-    if feature.name.startswith("ui_"):
+    if feature.rel_filename.startswith("ui/"):
         try:
             browser = request.getfixturevalue('browser')
             url = "{}/user/logout".format(portal_url)


### PR DESCRIPTION
Use the relative filename of the feature and not the human readable description. Assumes all our UI tests use features from the "ui" subdirectory.

Fixes unwanted regression in 'eed72bee11e: Prevent starting a browser for API tests.".

That commit effectively also prevented logging out during UI tests, reverting the intention of "4f242e6273ae Logout test users to prevent overloading test system with iRODS agents."

Not logging out leads to lots of irodsServer processes hanging around with considerable resource usage, especially system memory.

https://github.com/pytest-dev/pytest-bdd/blob/master/src/pytest_bdd/parser.py

...
@dataclass
class Feature:
    scenarios: OrderedDict[str, ScenarioTemplate]
    filename: str
    rel_filename: str
    name: str | None
    tags: set[str]
    background: Background | None
    line_number: int
    description: str

In e.g. using tests/features/ui/ui_homepage.feature the following will be roughly the case:

    feature.name         = Homepage UI
    feature.filename     = /home/user/src/UtrechtUniversity/yoda-portal/tests/ui/ui_homepage.feature
    feature.rel_filename = ui/ui_homepage.feature