### PR TITLE
YDA-5024: Move pysqlcipher3 to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ irods-avu-json==2.2.0
 python2-secrets==1.0.5
 python-dateutil==2.7.0
 certifi==2021.10.8
+pysqlcipher3==1.0.4


### PR DESCRIPTION
Move pysqlcipher3 from playbook to ruleset dependencies, since it is always imported, irrespective of whether data access tokens are enabled.