### PR TITLE
YDA-4925: add API endpoint delete expired DAPs

### DIFF
--- a/data_access_token.py
+++ b/data_access_token.py
@@ -15,7 +15,8 @@ from util import *
 
 __all__ = ['api_token_generate',
            'api_token_load',
-           'api_token_delete']
+           'api_token_delete',
+           'api_token_delete_expired']
 
 
 @api.make()
@@ -117,6 +118,37 @@ def api_token_delete(ctx, label):
         with conn:
             conn.execute("PRAGMA key='%s'" % (config.token_database_password))
             conn.execute('''DELETE FROM tokens WHERE user = ? AND label = ?''', (user_id, label))
+            result = api.Result.ok()
+    except Exception:
+        print_exc()
+        result = api.Error('DatabaseError', 'Error during deletion from database')
+
+    # Connection object used as context manager only commits or rollbacks transactions,
+    # so the connection object should be closed manually
+    conn.close()
+
+    return result
+
+
+@api.make()
+def api_token_delete_expired(ctx):
+    """Deletes expired tokens of current user
+
+    :param ctx:   Combined type of a callback and rei struct
+
+    :returns: Status of token deletion
+    """
+    if not token_database_initialized():
+        return api.Error('DatabaseError', 'Internal error: token database unavailable')
+
+    user_id = user.name(ctx)
+    conn = sqlite3.connect(config.token_database)
+    result = None
+
+    try:
+        with conn:
+            conn.execute("PRAGMA key='%s'" % (config.token_database_password))
+            conn.execute('''DELETE FROM tokens WHERE user = ? AND exp_time < ? ''', (user_id, datetime.now()))
             result = api.Result.ok()
     except Exception:
         print_exc()

--- a/tests/features/api/api_token.feature
+++ b/tests/features/api/api_token.feature
@@ -13,6 +13,11 @@ Feature: Token API
             | api_test_token_4 |
             | api_test_token_5 |
 
+    Scenario: Token delete expired
+        Given user researcher is authenticated
+        And the Yoda token delete expired API is queried
+        Then the response status code is "200"
+
 
     Scenario: Token load
         Given user researcher is authenticated

--- a/tests/step_defs/api/test_api_token.py
+++ b/tests/step_defs/api/test_api_token.py
@@ -25,6 +25,15 @@ def api_token_generate(user, label):
     )
 
 
+@given('the Yoda token delete expired API is queried', target_fixture="api_response")
+def api_token_delete_expired(user):
+    return api_request(
+        user,
+        "token_delete_expired",
+        {}
+    )
+
+
 @given('the Yoda token load API is queried', target_fixture="api_response")
 def api_token_load(user):
     return api_request(


### PR DESCRIPTION
Add API endpoint to delete expired data access passwords. Called from portal in order to prevent label conflicts between newly created tokens and expired tokens that are no longer visible to user.