### PR TITLE
Intake API tests: update study, dataset, coll

### DIFF
--- a/tests/features/api/api_intake.feature
+++ b/tests/features/api/api_intake.feature
@@ -103,7 +103,6 @@ Feature: Intake API
 
     Scenario Outline: Get all details for a dataset
         Given user <user> is authenticated
-        And dataset exists
         And the Yoda intake dataset get details API is queried with dataset id <dataset_id> and collection <collection>
         Then the response status code is "200"
         # And ...

--- a/tests/features/api/api_intake.feature
+++ b/tests/features/api/api_intake.feature
@@ -24,7 +24,7 @@ Feature: Intake API
         Examples:
             | user        | study   |
             | datamanager | initial |
-            | datamanager | test |
+            | datamanager | test    |
 
 
     Scenario Outline: Get the total count of all files in a collection
@@ -34,9 +34,9 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | collection                      |
-            | datamanager | /tempZone/yoda/home/grp-initial |
-            | researcher  | /tempZone/yoda/home/grp-initial |
+            | user        | collection                        |
+            | datamanager | /tempZone/home/grp-intake-initial |
+            | researcher  | /tempZone/home/grp-intake-initial |
 
 
     Scenario Outline: Get list of all unrecognized and unscanned files
@@ -46,9 +46,9 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | collection                      |
-            | datamanager | /tempZone/yoda/home/grp-initial |
-            | researcher  | /tempZone/yoda/home/grp-initial |
+            | user        | collection                        |
+            | datamanager | /tempZone/yoda/grp-intake-initial |
+            | researcher  | /tempZone/yoda/grp-intake-initial |
 
 
     Scenario Outline: Get list of all datasets
@@ -58,9 +58,9 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | collection                      |
-            | datamanager | /tempZone/yoda/home/grp-initial |
-            | researcher  | /tempZone/yoda/home/grp-initial |
+            | user        | collection                        |
+            | datamanager | /tempZone/home/grp-intake-initial |
+            | researcher  | /tempZone/home/grp-intake-initial |
 
 
     Scenario Outline: Scan for and recognize datasets in study intake area
@@ -70,9 +70,9 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | collection                      |
-            | datamanager | /tempZone/yoda/home/grp-initial |
-            | researcher  | /tempZone/yoda/home/grp-initial |
+            | user        | collection                        |
+            | datamanager | /tempZone/home/grp-intake-initial |
+            | researcher  | /tempZone/home/grp-intake-initial |
 
 
     Scenario Outline: Lock dataset in study intake area
@@ -83,9 +83,9 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | collection                      |
-            | datamanager | /tempZone/yoda/home/grp-initial |
-            | researcher  | /tempZone/yoda/home/grp-initial |
+            | user        | collection                        |
+            | datamanager | /tempZone/home/grp-intake-initial |
+            | researcher  | /tempZone/home/grp-intake-initial |
 
 
     Scenario Outline: Unlock dataset in study intake area
@@ -96,22 +96,22 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | collection                      |
-            | datamanager | /tempZone/yoda/home/grp-initial |
-            | researcher  | /tempZone/yoda/home/grp-initial |
+            | user        | collection                        |
+            | datamanager | /tempZone/home/grp-intake-initial |
+            | researcher  | /tempZone/home/grp-intake-initial |
 
 
     Scenario Outline: Get all details for a dataset
         Given user <user> is authenticated
         And dataset exists
-        And the Yoda intake dataset get details API is queried with dataset id and collection <collection>
+        And the Yoda intake dataset get details API is queried with dataset id <dataset_id> and collection <collection>
         Then the response status code is "200"
         # And ...
 
         Examples:
-            | user        | collection                      |
-            | datamanager | /tempZone/yoda/home/grp-initial |
-            | researcher  | /tempZone/yoda/home/grp-initial |
+            | user        | collection                             | dataset_id              |
+            | datamanager | /tempZone/home/grp-intake-initial      | 3y*discount*B00000*Raw  |
+            | researcher  | /tempZone/home/grp-intake-initial      | 3y*discount*B00001*Raw  |
 
 
     Scenario Outline: Add a comment to a dataset
@@ -122,9 +122,9 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | study_id | comment |
-            | datamanager | initial  | initial |
-            | researcher  | initial  | initial |
+            | user        | study_id            | comment |
+            | datamanager | grp-intake-initial  | initial |
+            | researcher  | grp-intake-initial  | initial |
 
 
     Scenario Outline: Get vault dataset related counts for reporting for a study
@@ -134,8 +134,8 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | study_id   |
-            | datamanager | initial    |
+            | user        | study_id              |
+            | datamanager | grp-intake-initial    |
 
 
     Scenario Outline: Get aggregated vault dataset info for reporting for a study
@@ -145,8 +145,8 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | study_id |
-            | datamanager | initial  |
+            | user        | study_id            |
+            | datamanager | grp-intake-initial  |
 
 
     Scenario Outline: Get vault data for export of a study
@@ -156,5 +156,5 @@ Feature: Intake API
         # And ...
 
         Examples:
-            | user        | study_id |
-            | datamanager | initial  |
+            | user        | study_id            |
+            | datamanager | grp-intake-initial  |

--- a/tests/step_defs/api/test_api_intake.py
+++ b/tests/step_defs/api/test_api_intake.py
@@ -88,12 +88,12 @@ def api_intake_unlock_dataset(user, dataset_id, collection):
     )
 
 
-@given(parsers.parse("the Yoda intake dataset get details API is queried with dataset id and collection {collection}"), target_fixture="api_response")
+@given(parsers.parse("the Yoda intake dataset get details API is queried with dataset id {dataset_id} and collection {collection}"), target_fixture="api_response")
 def api_intake_dataset_get_details(user, dataset_id, collection):
     return api_request(
         user,
         "intake_dataset_get_details",
-        {"coll": collection, "dataset_id": dataset_id}
+        {"coll": collection, "dataset_id": dataset_id.replace("*", "\t")}
     )
 
 


### PR DESCRIPTION
- Study_id has a new format, now that the intake module supports both grp-intake-* and intake-* groups.
- Dataset_id needs to be set to a particular dataset ID that is added by the test playbook.
- Update collection names so that they match the test dataset

Please note that PR #247 is also needed to make the intake tests pass completely