### PR TITLE
YDA-5048: fix silent failures intake module

### DIFF
--- a/intake.py
+++ b/intake.py
@@ -592,6 +592,10 @@ def api_intake_dataset_add_comment(ctx, study_id, dataset_id, comment):
     is_collection = tl_info['is_collection']
     tl_objects = tl_info['objects']
 
+    if not is_collection and len(tl_objects) == 0:
+        return {"proc_status": "NOK",
+                "error_msg": "Dataset does not exist"}
+
     timestamp = int(time.time())  # int(datetime.timestamp(datetime.now()))
     comment_data = user.name(ctx) + ':' + str(timestamp) + ':' + comment
 

--- a/intake_lock.py
+++ b/intake_lock.py
@@ -94,6 +94,9 @@ def intake_dataset_lock(ctx, collection, dataset_id):
     tl_objects = tl_info['objects']
     log.write(ctx, tl_info)
 
+    if not is_collection and len(tl_objects) == 0:
+        raise Exception("Dataset \"{}\" in collection {} not found".format(collection, dataset_id))
+
     if is_collection:
         intake_dataset_change_status(ctx, tl_objects[0], is_collection, dataset_id, "to_vault_lock", timestamp, False)
     else:
@@ -108,6 +111,9 @@ def intake_dataset_unlock(ctx, collection, dataset_id):
     tl_info = intake.get_dataset_toplevel_objects(ctx, collection, dataset_id)
     is_collection = tl_info['is_collection']
     tl_objects = tl_info['objects']
+
+    if not is_collection and len(tl_objects) == 0:
+        raise Exception("Dataset \"{}\" in collection {} not found".format(collection, dataset_id))
 
     # It is possible that the status of the dataset status has moved on.
     if is_collection:

--- a/tests/features/api/api_intake.feature
+++ b/tests/features/api/api_intake.feature
@@ -77,28 +77,52 @@ Feature: Intake API
 
     Scenario Outline: Lock dataset in study intake area
         Given user <user> is authenticated
-        And dataset exists
-        And the Yoda intake lock API is queried with dataset id and collection <collection>
+        And the Yoda intake lock API is queried with dataset id <dataset_id> and collection <collection>
         Then the response status code is "200"
         # And ...
 
         Examples:
-            | user        | collection                        |
-            | datamanager | /tempZone/home/grp-intake-initial |
-            | researcher  | /tempZone/home/grp-intake-initial |
+            | user        | collection                        | dataset_id              |
+            | datamanager | /tempZone/home/grp-intake-initial | 3y*discount*B00000*Raw  |
+            | researcher  | /tempZone/home/grp-intake-initial | 3y*discount*B00001*Raw  |
+
+
+    Scenario Outline: Cannot lock non-existent dataset
+        Given user <user> is authenticated
+        And the Yoda intake lock API is queried with dataset id <dataset_id> and collection <collection>
+        # Errors during locking individual datasets do not result in an error status code. This test
+        # codifies current behaviour of this API endpoint.
+        Then the response status code is "200"
+        And the result is equivalent to {"error_dataset_ids": ["3y\ndiscount\nB99999\nRaw"], "error_msg": "Something went wrong locking datasets", "proc_status": "NOK"}
+
+        Examples:
+            | user        | collection                        | dataset_id             |
+            | datamanager | /tempZone/home/grp-intake-initial | 3y*discount*B99999*Raw |
 
 
     Scenario Outline: Unlock dataset in study intake area
         Given user <user> is authenticated
-        And dataset exists
-        And the Yoda intake unlock API is queried with dataset id and collection <collection>
+        And the Yoda intake unlock API is queried with dataset id <dataset_id> and collection <collection>
         Then the response status code is "200"
         # And ...
 
         Examples:
-            | user        | collection                        |
-            | datamanager | /tempZone/home/grp-intake-initial |
-            | researcher  | /tempZone/home/grp-intake-initial |
+            | user        | collection                        | dataset_id             |
+            | datamanager | /tempZone/home/grp-intake-initial | 3y*discount*B00000*Raw |
+            | researcher  | /tempZone/home/grp-intake-initial | 3y*discount*B00001*Raw |
+
+
+    Scenario Outline: Cannot unlock non-existent dataset
+        Given user <user> is authenticated
+        And the Yoda intake unlock API is queried with dataset id <dataset_id> and collection <collection>
+        # Errors during unlocking individual datasets do not result in an error status code. This test
+        # codifies current behaviour of this API endpoint.
+        Then the response status code is "200"
+        And the result is equivalent to {"error_dataset_ids": ["3y\ndiscount\nB99999\nRaw"], "error_msg": "Something went wrong unlocking datasets", "proc_status": "NOK"}
+
+        Examples:
+            | user        | collection                        | dataset_id             |
+            | datamanager | /tempZone/home/grp-intake-initial | 3y*discount*B99999*Raw |
 
 
     Scenario Outline: Get all details for a dataset
@@ -115,15 +139,27 @@ Feature: Intake API
 
     Scenario Outline: Add a comment to a dataset
         Given user <user> is authenticated
-        And dataset exists
-        And the Yoda intake dataset add comment API is queried with dataset id, study id <study_id> and comment <comment>
+        And the Yoda intake dataset add comment API is queried with dataset id <dataset_id>, study id <study_id> and comment <comment>
         Then the response status code is "200"
         # And ...
 
         Examples:
-            | user        | study_id            | comment |
-            | datamanager | grp-intake-initial  | initial |
-            | researcher  | grp-intake-initial  | initial |
+            | user        | study_id            | comment  | dataset_id             |
+            | datamanager | grp-intake-initial  | comment1 | 3y*discount*B00000*Raw |
+            | researcher  | grp-intake-initial  | comment2 | 3y*discount*B00001*Raw |
+
+
+    Scenario Outline: Cannot add comment to nonexistent dataset
+        Given user <user> is authenticated
+        And the Yoda intake dataset add comment API is queried with dataset id <dataset_id>, study id <study_id> and comment <comment>
+        # Adding a comment to a nonexistent dataset currently does not result in an error status code. This test
+        # codifies current behaviour of this API endpoint.
+        Then the response status code is "200"
+        And the result is equivalent to {"error_msg": "Dataset does not exist", "proc_status": "NOK"}
+
+        Examples:
+            | user        | study_id            | comment  | dataset_id             |
+            | datamanager | grp-intake-initial  | comment1 | 3y*discount*B99999*Raw |
 
 
     Scenario Outline: Get vault dataset related counts for reporting for a study

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ selenium==4.7.2
 pytest-splinter==3.3.2
 pytest_bdd==6.1.1
 pytest==7.2.0
+deepdiff==5.8.1


### PR DESCRIPTION
Fix silent failures on intake module API calls for locking, unlocking and adding a comment to a dataset. Also add API tests for this scenario.