### PR TITLE
YDA-5036: Fix error handling secure copy

### DIFF
--- a/iiVault.r
+++ b/iiVault.r
@@ -125,8 +125,9 @@ iiCopyObject(*itemParent, *itemName, *itemIsCollection, *buffer, *error) {
 # \param[out] err         return the error to calling function
 #
 iiGenericSecureCopy(*argv, *origin_path, *err) {
-        *err = errorcode(msiExecCmd("securecopy.sh", *argv, "", *origin_path, 1, *cmdExecOut));
-        if (*err < 0) {
+        *intErr = errorcode(msiExecCmd("securecopy.sh", *argv, "", *origin_path, 1, *cmdExecOut));
+        *err = str(*intErr);
+        if (*intErr < 0 ) {
                 msiGetStderrInExecCmdOut(*cmdExecOut, *stderr);
                 msiGetStdoutInExecCmdOut(*cmdExecOut, *stdout);
                 writeLine("serverLog", "iiGenericSecureCopy: errorcode *err");

--- a/publication.py
+++ b/publication.py
@@ -496,13 +496,13 @@ def copy_landingpage_to_public_host(ctx, random_id, publication_config, publicat
 
     argv = publicHost + " inbox /var/www/landingpages/" + publicPath
 
-    error = 0
-    ctx.iiGenericSecureCopy(argv, landingPagePath, error)
-    if error >= 0:
+    copy_result = ctx.iiGenericSecureCopy(argv, landingPagePath, '')
+    error = copy_result['arguments'][2]
+    if int(error) >= 0:
         publication_state["landingPageUploaded"] = "yes"
     else:
         publication_state["status"] = "Retry"
-        log.write(ctx, "copy_landingpage_to_public: " + str(error))
+        log.write(ctx, "copy_landingpage_to_public: " + error)
 
 
 def copy_metadata_to_moai(ctx, random_id, publication_config, publication_state):
@@ -519,9 +519,9 @@ def copy_metadata_to_moai(ctx, random_id, publication_config, publication_state)
     combiJsonPath = publication_state["combiJsonPath"]
 
     argv = publicHost + " inbox /var/www/moai/metadata/" + yodaInstance + "/" + yodaPrefix + "/" + random_id + ".json"
-    error = 0
-    ctx.iiGenericSecureCopy(argv, combiJsonPath, error)
-    if error >= 0:
+    copy_result = ctx.iiGenericSecureCopy(argv, combiJsonPath, '')
+    error = copy_result['arguments'][2]
+    if int(error) >= 0:
         publication_state["oaiUploaded"] = "yes"
     else:
         publication_state["status"] = "Retry"


### PR DESCRIPTION
Update the publication logic so that it takes into account error codes returned by the msiExecCmd microservice used for transferring data to the public server. The previous logic always set the error code to 0, because of the interaction between the legacy rule language secure-copy rule and the rest of the logic in the PREP.