### PR TITLE
Persist publication state after errors in checking DOI availability

### DIFF
--- a/publication.py
+++ b/publication.py
@@ -720,6 +720,8 @@ def process_publication(ctx, vault_package):
                 log.write(ctx, "Error while checking DOI availability.")
             publication_state["status"] = "Retry"
 
+        save_publication_state(ctx, vault_package, publication_state)
+
         if publication_state["status"] == "Retry":
             if verbose:
                 log.write(ctx, "Error status after checking DOI availability.")


### PR DESCRIPTION
This makes the "retry" process working better, as otherwise the publication can get into an endless loop.

This bug could happen when posting a DOI did work, but the acknowledgement run into a timeout and wasn't received. The fact that we did already try an upload wasn't registered then in the status. On the next retry we then hit an unexpected status in the state machine and again went to "retry".