### PR TITLE
YDA-5149: improve subcategory performance

### DIFF
--- a/groups.py
+++ b/groups.py
@@ -165,7 +165,7 @@ def getSubcategories(ctx, category):
     # to `categories` if the category name matches.
     iter = genquery.row_iterator(
         "USER_GROUP_NAME, META_USER_ATTR_NAME, META_USER_ATTR_VALUE",
-        "USER_TYPE = 'rodsgroup' AND META_USER_ATTR_NAME LIKE '%category'",
+        "USER_TYPE = 'rodsgroup' AND META_USER_ATTR_NAME IN('category','subcategory')",
         genquery.AS_LIST, ctx
     )
 


### PR DESCRIPTION
Optimize genquery for finding category/subcategory to use default iCAT database indexes. This improves subcategory autocompletion performance in the group manager substantially on large environments.