### PR TITLE
YDA-5023 - Set Yoda flags to use Collections on the Yoda flags system collection so that replication and revision jobs are not triggered

### DIFF
--- a/replication.py
+++ b/replication.py
@@ -152,9 +152,5 @@ def is_replication_blocked_by_admin(ctx):
     :returns: Boolean indicating if admin put replication on hold.
     """
     zone = user.zone(ctx)
-    iter = genquery.row_iterator(
-        "DATA_ID",
-        "COLL_NAME = '" + "/{}/yoda/flags".format(zone) + "' AND DATA_NAME = 'stop_replication'",
-        genquery.AS_LIST, ctx
-    )
-    return len(list(iter)) > 0
+    path = "/{}/yoda/flags/stop_replication".format(zone)
+    return collection.exists(ctx, path)

--- a/revisions.py
+++ b/revisions.py
@@ -363,12 +363,8 @@ def is_revision_blocked_by_admin(ctx):
     :returns: Boolean indicating if admin put replication on hold.
     """
     zone = user.zone(ctx)
-    iter = genquery.row_iterator(
-        "DATA_ID",
-        "COLL_NAME = '" + "/{}/yoda/flags".format(zone) + "' AND DATA_NAME = 'stop_revisions'",
-        genquery.AS_LIST, ctx
-    )
-    return (len(list(iter)) > 0)
+    path = "/{}/yoda/flags/stop_revisions".format(zone)
+    return collection.exists(ctx, path)
 
 
 def revision_create(ctx, resource, data_id, max_size, verbose):


### PR DESCRIPTION
YDA-5023 - Set Yoda flags to use Collections on the Yoda flags system collection so that replication and revision jobs are not triggered