### PR TITLE
solved error occurring when running same test twice

### DIFF
--- a/tests/step_defs/ui/test_ui_statistics.py
+++ b/tests/step_defs/ui/test_ui_statistics.py
@@ -5,6 +5,7 @@ __copyright__ = 'Copyright (c) 2020-2023, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import os
+import time
 from pathlib import Path
 
 from pytest_bdd import (
@@ -24,6 +25,7 @@ def ui_statistics_group_details_initial_state(browser):
 
 @when(parsers.parse("user views statistics of group {group}"))
 def ui_statistics_group_view(browser, group):
+    time.sleep(1)
     next_page = True
     while next_page:
         # Next page available, button is not disabled.


### PR DESCRIPTION
simple change not related to the actual functionality.
The tests itself did not need to be altered and work fine after adding the totalization of storage and counts of internal/external users