### PR TITLE
solves errors in rodsLog RE_TYPE_ERROR and UNMATCHED_KEY_OR_INDEX

### DIFF
--- a/iiDatamanagerPolicies.r
+++ b/iiDatamanagerPolicies.r
@@ -25,22 +25,15 @@ acPreSudoObjAclSet(*recursive, *accessLevel, *otherName, *objPath, *policyKv) {
 # \param[in] policyKv
 #
 iiDatamanagerPreSudoObjAclSet(*recursive, *accessLevel, *otherName, *objPath, *policyKv) {
-        # It is incorrect to assume that attribute 'actor' exists. Or even *policyKv.
-        # If it is not, an error will occur: RE_TYPE_ERROR
-	# *actor = *policyKv.actor;
-
-        # Initially current user will be set as actor.
-        # If policyKv holds another, then that actor will overrule the initial setting.
-        # If no actor is set, this will lead to the error: UNMATCHED_KEY_OR_INDEX
-        *actor = uuClientFullName;
-        foreach(*key in *policyKv) {
-            if (*key == "actor") {
-                *actor = *policyKv.actor
-                writeLine("serverLog", "actor found");
-                writeLine("serverLog", *actor);
-                break;
-            }
-        }
+	# Initially current user will be set as actor.
+	# If policyKv holds another, then that actor will override.
+	*actor = uuClientFullName;
+	foreach(*key in *policyKv) {
+		if (*key == "actor") {
+			*actor = *policyKv.actor
+			break;
+		}
+	}
 
 	iiCanDatamanagerAclSet(*objPath, *actor, *otherName, *recursive, *accessLevel, *allowed, *reason);
 	writeLine("serverLog", "iiDatamanagerPreSudoObjAclSet: *reason");

--- a/iiDatamanagerPolicies.r
+++ b/iiDatamanagerPolicies.r
@@ -25,7 +25,23 @@ acPreSudoObjAclSet(*recursive, *accessLevel, *otherName, *objPath, *policyKv) {
 # \param[in] policyKv
 #
 iiDatamanagerPreSudoObjAclSet(*recursive, *accessLevel, *otherName, *objPath, *policyKv) {
-	*actor = *policyKv.actor;
+        # It is incorrect to assume that attribute 'actor' exists. Or even *policyKv.
+        # If it is not, an error will occur: RE_TYPE_ERROR
+	# *actor = *policyKv.actor;
+
+        # Initially current user will be set as actor.
+        # If policyKv holds another, then that actor will overrule the initial setting.
+        # If no actor is set, this will lead to the error: UNMATCHED_KEY_OR_INDEX
+        *actor = uuClientFullName;
+        foreach(*key in *policyKv) {
+            if (*key == "actor") {
+                *actor = *policyKv.actor
+                writeLine("serverLog", "actor found");
+                writeLine("serverLog", *actor);
+                break;
+            }
+        }
+
 	iiCanDatamanagerAclSet(*objPath, *actor, *otherName, *recursive, *accessLevel, *allowed, *reason);
 	writeLine("serverLog", "iiDatamanagerPreSudoObjAclSet: *reason");
 	if (*allowed) {


### PR DESCRIPTION
Hi Lazlo,
This intervention solves the symptoms (errors RE_TYPE_ERROR and UNMATCHED_KEY_OR_INDEX) that popup in the rodsLog when creating a new group.
The key lies in the absence of either "actor" as an attribute of *policyKv or even absence of *policyKv entirely.

What I have added, is that when no actor is present the actor false back to the current user. 

However, I have not addressed the reason why the actor is absent. I found that too complicated.

