### PR TITLE
Extract Python 3 interpreter path parameter

### DIFF
--- a/meta.py
+++ b/meta.py
@@ -113,7 +113,7 @@ def get_json_metadata_errors(callback,
 
     # Create gateway to Python 3.8.
     import execnet
-    gw = execnet.makegateway("popen//python=/usr/local/bin/python3")
+    gw = execnet.makegateway("popen//python=" + config.python3_interpreter)
 
     channel = gw.remote_exec("""
         import jsonschema

--- a/rules_uu.cfg.template
+++ b/rules_uu.cfg.template
@@ -67,8 +67,9 @@ sram_api_key                   =
 sram_verbose_logging           =
 sram_tls_verify                =
 
-
 arb_enabled                    =
 arb_exempt_resources           =
 arb_min_gb_free                =
 arb_min_percent_free           =
+
+python3_interpreter            =

--- a/util/config.py
+++ b/util/config.py
@@ -139,7 +139,8 @@ config = Config(environment=None,
                 arb_exempt_resources=[],
                 arb_min_gb_free=0,
                 arb_min_percent_free=5,
-                text_file_extensions=[])
+                text_file_extensions=[],
+                python3_interpreter='/usr/local/bin/python3')
 
 # }}}
 


### PR DESCRIPTION
So that we can use the ruleset on distributions that have python3 in different places (initially used for adding Ubuntu 20.04 LTS support)

(depends on https://github.com/UtrechtUniversity/yoda/pull/361)