### PR TITLE
YDA-5605: make Scopus ID validation less strict

### DIFF
--- a/schemas/core-2/metadata.json
+++ b/schemas/core-2/metadata.json
@@ -774,7 +774,7 @@
                       "Name_Identifier": {
                         "type": "string",
                         "title": "Identifier",
-                        "pattern": "[0-9]{11}"
+                        "pattern": "[0-9]+"
                       }
                     }
                   }

--- a/schemas/default-3/metadata.json
+++ b/schemas/default-3/metadata.json
@@ -1042,7 +1042,7 @@
                       "Name_Identifier": {
                         "type": "string",
                         "title": "Identifier",
-                        "pattern": "[0-9]{11}"
+                        "pattern": "[0-9]+"
                       }
                     }
                   }

--- a/schemas/epos-msl-0/metadata.json
+++ b/schemas/epos-msl-0/metadata.json
@@ -1215,7 +1215,7 @@
                       "Name_Identifier": {
                         "type": "string",
                         "title": "Identifier",
-                        "pattern": "[0-9]{11}"
+                        "pattern": "[0-9]+"
                       }
                     }
                   }


### PR DESCRIPTION
Scopus Helpdesk confirmed that there is no standard for the number of digits in a Scopus ID, so we will accept any length.