### PR TITLE
YDA-5726: improve ORCID transformation rule

### DIFF
--- a/schema_transformation.py
+++ b/schema_transformation.py
@@ -215,6 +215,7 @@ def rule_batch_vault_metadata_correct_orcid_format(rule_args, callback, rei):
                       [1] Batch size, <= 256
                       [2] Pause between checks (float)
                       [3] Delay between batches in seconds
+                      [4] Dry-run mode ('true' or 'false'; everything else is considered 'false')
     :param callback:  Callback to rule Language
     :param rei:       The rei struct
     """
@@ -223,6 +224,7 @@ def rule_batch_vault_metadata_correct_orcid_format(rule_args, callback, rei):
     batch   = int(rule_args[1])
     pause   = float(rule_args[2])
     delay   = int(rule_args[3])
+    dryrun_mode = rule_args[4] == "true"
     rods_zone = session_vars.get_map(rei)["client_user"]["irods_zone"]
 
     # Check one batch of metadata schemas.
@@ -239,39 +241,43 @@ def rule_batch_vault_metadata_correct_orcid_format(rule_args, callback, rei):
         coll_name = row[1]
         path_parts = coll_name.split('/')
 
-        # ORCID-correction is limited to ['core-1', 'default-1', 'default-2', 'hptlab-1', 'teclab-1', 'dag-0', 'vollmer-0']
-        if path_parts[3].replace('vault-', '') in ['core-1', 'default-1', 'default-2', 'hptlab-1', 'teclab-1', 'dag-0', 'vollmer-0']:
-            try:
-                # Get vault package path.
-                vault_package = '/'.join(path_parts[:5])
-                metadata_path = meta.get_latest_vault_metadata_path(callback, vault_package)
-                if metadata_path  != '':
-                    # PREVENT EACH VAULT METADATA.JSON FILE FROM BEING REWRITTEN
-                    # Prevent transformation of every latest metadata.json file.
-                    # Possibly an individual file does not contain ORCID or illformatted ORCID.
-                    # Skip these files!
-                    metadata = jsonutil.read(callback, metadata_path)
+        try:
+            # Get vault package path.
+            vault_package = '/'.join(path_parts[:5])
+            metadata_path = meta.get_latest_vault_metadata_path(callback, vault_package)
+            if metadata_path  != '':
+                metadata = jsonutil.read(callback, metadata_path)
 
-                    # Correct the incorrect orcid(s) if possible
-                    # result is a dict containing 'data_changed' 'metadata'
-                    result = transform_orcid(callback, metadata)
+                # We only need to transform metadata with schemas that do not constrain ORCID format
+                license_url = metadata.get("links", {})[0].get("href", "")
+                license = license_url.replace("https://yoda.uu.nl/schemas/", "").replace("/metadata.json", "")
+                if license not in ['core-1', 'core-2', 'default-1', 'default-2', 'default-3', 'hptlab-1', 'teclab-1', 'dag-0', 'vollmer-0']:
+                    log.write(callback, "Skipping data package '%s' for ORCID transformation because license '%s' is excluded."
+                              % (vault_package, license))
+                    continue
 
-                    # In order to minimize changes within the vault only save a new metadata.json if there actually has been at least one orcid correction.
-                    if result['data_changed']:
-                        # orcid('s) has/have been adjusted. Save the changes in the same manner as execute_transformation for vault packages.
-                        coll, data = os.path.split(metadata_path)
-                        new_path = '{}/yoda-metadata[{}].json'.format(coll, str(int(time.time())))
-                        # print('TRANSFORMING in vault <{}> -> <{}>'.format(metadata_path, new_path))
-                        jsonutil.write(callback, new_path, result['metadata'])
-                        copy_acls_from_parent(callback, new_path, "default")
-                        callback.rule_provenance_log_action("system", coll, "updated person identifier metadata")
-                        log.write(callback, "Transformed ORCIDs for: %s" % (new_path))
+                # Correct the incorrect orcid(s) if possible
+                # result is a dict containing 'data_changed' 'metadata'
+                result = transform_orcid(callback, metadata)
 
-            except Exception:
-                pass
+                # In order to minimize changes within the vault only save a new metadata.json if there actually has been at least one orcid correction.
+                if result['data_changed'] and not dryrun_mode:
+                    # orcid('s) has/have been adjusted. Save the changes in the same manner as execute_transformation for vault packages.
+                    coll, data = os.path.split(metadata_path)
+                    new_path = '{}/yoda-metadata[{}].json'.format(coll, str(int(time.time())))
+                    log.write(callback, 'TRANSFORMING in vault <{}> -> <{}>'.format(metadata_path, new_path))
+                    jsonutil.write(callback, new_path, result['metadata'])
+                    copy_acls_from_parent(callback, new_path, "default")
+                    callback.rule_provenance_log_action("system", coll, "updated person identifier metadata")
+                    log.write(callback, "Transformed ORCIDs for: %s" % (new_path))
+                elif result['data_changed']:
+                    log.write(callback, "Would have transformed ORCIDs for: %s if dry run mode was disabled." % (metadata_path))
 
-            # Sleep briefly between checks.
-            time.sleep(pause)
+        except Exception as e:
+            log.write(callback, "Exception occurred during ORCID transformation of %s: %s" % (coll_name, str(e)))
+
+        # Sleep briefly between checks.
+        time.sleep(pause)
 
         # The next collection to check must have a higher COLL_ID.
         coll_id += 1
@@ -307,17 +313,21 @@ def transform_orcid(ctx, m):
                     if pi.get('Name_Identifier_Scheme', None)  == 'ORCID':
                         # If incorrect ORCID format => try to correct.
                         if not re.search("^(https://orcid.org/)[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$", pi.get('Name_Identifier', None)):
-                            corrected_orcid = correctify_orcid(pi['Name_Identifier'])
+                            original_orcid = pi['Name_Identifier']
+                            corrected_orcid = correctify_orcid(original_orcid)
                             # Only it an actual correction took place change the value and mark this data as 'changed'.
-                            if corrected_orcid != pi['Name_Identifier']:
-                                pi['Name_Identifier'] = correctify_orcid(pi['Name_Identifier'])
+                            if corrected_orcid is None:
+                                log.write(ctx, "Warning: unable to automatically fix ORCID '%s'" % (original_orcid))
+                            elif corrected_orcid != original_orcid:
+                                log.write(ctx, "Updating ORCID '%s' to '%s'" % (original_orcid, corrected_orcid))
+                                pi['Name_Identifier'] = corrected_orcid
                                 data_changed = True
 
     return {'metadata': m, 'data_changed': data_changed}
 
 
 def correctify_orcid(org_orcid):
-    """Function to correct illformatted ORCIDs."""
+    """Function to correct illformatted ORCIDs. Returns None if value cannot be fixed."""
     # Get rid of all spaces.
     orcid = org_orcid.replace(' ', '')
 
@@ -328,8 +338,7 @@ def correctify_orcid(org_orcid):
     # If not, it is impossible to correct it to the valid orcid format
     orcs = orcid.split('/')
     if not re.search("^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$", orcs[-1]):
-        # Return original value.
-        return org_orcid
+        return None
 
     return "https://orcid.org/{}".format(orcs[-1])
 

--- a/tools/metadata/vault-correct-orcid-format.r
+++ b/tools/metadata/vault-correct-orcid-format.r
@@ -4,8 +4,8 @@
 #
 check {
         writeLine("serverLog", "[METADATA] Start correcting ORCID format in person identifers.");
-        rule_batch_vault_metadata_correct_orcid_format("0", *batch, *pause, *delay);
+        rule_batch_vault_metadata_correct_orcid_format("0", *batch, *pause, *delay, *dryrun);
 }
 
-input *batch="256", *pause="0.5", *delay="60"
+input *batch="256", *pause="0.5", *delay="60", *dryrun="false"
 output ruleExecOut


### PR DESCRIPTION
Improve rule for transforming illformatted ORCID identifiers in multiple ways:
- Log more information, in particular print information about exceptions that occur, print any values that are transformed, and print values that cannot be transformed for verification and troubleshooting.
- Add a dry run mode
- Fix method for determining schema: use the schema identifier in the metadata file for this.
- Also transform default-3 and core-2 metadata, so that we have the option of running the ORCID transformation script after converting metadata to default-3/core-2.