### PR TITLE
YDA-5752: add vault metadata schema report

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -6,6 +6,7 @@ __license__   = 'GPLv3, see LICENSE'
 
 __all__ = ['rule_run_integration_tests']
 
+import json
 import re
 import time
 import traceback
@@ -328,6 +329,10 @@ basic_integration_tests = [
     {"name": "policies.check_anonymous_access_allowed.remote",
      "test": lambda ctx: ctx.rule_check_anonymous_access_allowed("1.2.3.4", ""),
      "check": lambda x: x['arguments'][1] == 'false'},
+    # Vault metadata schema report: only check return value type, not contents
+    {"name": "schema_transformation.batch_vault_metadata_schema_report",
+     "test": lambda ctx: ctx.rule_batch_vault_metadata_schema_report(""),
+     "check": lambda x: isinstance(json.loads(x['arguments'][0]), dict)},
     {"name":  "util.collection.exists.yes",
      "test": lambda ctx: collection.exists(ctx, "/tempZone/yoda"),
      "check": lambda x: x},

--- a/tools/metadata/vault-metadata-schema-report.r
+++ b/tools/metadata/vault-metadata-schema-report.r
@@ -1,0 +1,30 @@
+#!/usr/bin/irule -r irods_rule_engine_plugin-python-instance -F
+#
+# Prints a report of all vault data packages, their metadata schema
+# and whether the current metadata matches the schema. Errors are written
+# to the rodsLog.
+#
+# Output format: CSV, with the following columns:
+# 1. Data package collection
+# 2. Short schema name (e.g. "default-3")
+# 3. Boolean value that indicate whether the metadata matches the schema ("True"/"False")
+#
+
+import csv
+import io
+import json
+import genquery
+
+
+def main(rule_args, callback, rei):
+    result = callback.rule_batch_vault_metadata_schema_report("")
+    data = json.loads(result["arguments"][0])
+    for package in sorted(data):
+        output = io.BytesIO()
+        writer = csv.writer(output)
+        rowdata = [package, data[package]["schema"], str(data[package]["match_schema"])]
+        writer.writerow([column.encode('utf-8') for column in rowdata])
+        callback.writeLine("stdout", output.getvalue().strip())
+
+INPUT null
+OUTPUT ruleExecOut


### PR DESCRIPTION
Add report tool for compiling a list of all vault data packages, their active metadata schema and whether the metadata matches the schema. This is meant to be used for verifying metadata upgrades and changes.