### PR TITLE
Always enable irods_type_info

### DIFF
--- a/util/__init__.py
+++ b/util/__init__.py
@@ -39,6 +39,7 @@ if 'unittest' not in sys.modules.keys():
     import resource
     import arb_data_manager
     import cached_data_manager
+    import irods_type_info
 
     # Config items can be accessed directly as 'config.foo' by any module
     # that imports * from util.
@@ -48,5 +49,4 @@ if 'unittest' not in sys.modules.keys():
         import bagit
 
     if config.environment == 'development':
-        import irods_type_info
         ping = api_ping = api.make()(lambda ctx, x=42: x)


### PR DESCRIPTION
Always enable __repr__ functions that show content for iRODS data types. These functions are now used by the GenQuery safety policy in pep_database_gen_query_pre.

Also to be cherry-picked in backport-1.9.3