### PR TITLE
Yda 5734 add metadata pid url for downloadable content

### DIFF
--- a/json_landing_page.py
+++ b/json_landing_page.py
@@ -30,7 +30,7 @@ def persistent_identifier_to_uri(identifier_scheme, identifier):
     # Create a URI from the identifier scheme and identifier.
     uri = ""
     if identifier_scheme == 'DOI':
-        uri = "https://handle.test.datacite.org/{}".format(identifier)
+        uri = "https://doi.org/{}".format(identifier)
     elif identifier_scheme == 'ORCID':
         uri = "https://orcid.org/{}".format(identifier)
     elif identifier_scheme == 'Handle':

--- a/json_landing_page.py
+++ b/json_landing_page.py
@@ -30,7 +30,7 @@ def persistent_identifier_to_uri(identifier_scheme, identifier):
     # Create a URI from the identifier scheme and identifier.
     uri = ""
     if identifier_scheme == 'DOI':
-        uri = "https://doi.org/{}".format(identifier)
+        uri = "https://handle.test.datacite.org/{}".format(identifier)
     elif identifier_scheme == 'ORCID':
         uri = "https://orcid.org/{}".format(identifier)
     elif identifier_scheme == 'Handle':

--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -11,6 +11,7 @@
     <meta name="DC.publisher" content="Utrecht University">
     <meta name="DC.date" content="{{ publication_date }}" scheme="DCTERMS.W3CDTF">
     <meta name="DC.type" content="{{ datatype }}">
+    <meta name="DC.Relation" content="Has part {{ open_access_link }}>
     <title>{{ title }} - Data Publication platform of Utrecht University</title>
 
     <link href="/static/css/bootstrap.min.css?v=1559637767" rel="stylesheet">

--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -359,7 +359,7 @@
                                 <label class="indented">Type of relation</label>
                             </div>
                             <div class="col-sm-10">
-                                <span>{{ pack.Relation_Type }}</span>
+                                <span property="dc:relation">{{ pack.Relation_Type }}</span>
                             </div>
                         </div>
 
@@ -369,7 +369,7 @@
                                 <label class="indented">Persistent Identifier</label>
                             </div>
                             <div class="col-sm-10">
-                                <span property="dc:relation">
+                                <span>
                                 <a href="{{ persistent_identifier_to_uri(pack.Persistent_Identifier.Identifier_Scheme, pack.Persistent_Identifier.Identifier) }}" target="_blank">
                                   {{ persistent_identifier_to_uri(pack.Persistent_Identifier.Identifier_Scheme, pack.Persistent_Identifier.Identifier) }}
                                 </a>

--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -11,7 +11,9 @@
     <meta name="DC.publisher" content="Utrecht University">
     <meta name="DC.date" content="{{ publication_date }}" scheme="DCTERMS.W3CDTF">
     <meta name="DC.type" content="{{ datatype }}">
-    <meta name="DC.identifier" content="{{ open_access_link }}">
+    {%if no_active_embargo and data_access_restriction.startswith('Open') %}
+        <link rel="item" href="{{ open_access_link }}">
+    {% endif %}
     <title>{{ title }} - Data Publication platform of Utrecht University</title>
 
     <link href="/static/css/bootstrap.min.css?v=1559637767" rel="stylesheet">

--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -11,7 +11,7 @@
     <meta name="DC.publisher" content="Utrecht University">
     <meta name="DC.date" content="{{ publication_date }}" scheme="DCTERMS.W3CDTF">
     <meta name="DC.type" content="{{ datatype }}">
-    <meta name="DC.Relation" content="Has part {{ open_access_link }}>
+    <meta name="DC.Relation" content="Has part {{ open_access_link }}">
     <title>{{ title }} - Data Publication platform of Utrecht University</title>
 
     <link href="/static/css/bootstrap.min.css?v=1559637767" rel="stylesheet">

--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -11,7 +11,8 @@
     <meta name="DC.publisher" content="Utrecht University">
     <meta name="DC.date" content="{{ publication_date }}" scheme="DCTERMS.W3CDTF">
     <meta name="DC.type" content="{{ datatype }}">
-    <meta name="DC.Relation" content="Has part {{ open_access_link }}">
+    <meta name="DC.identifier" content="{{ open_access_link }}">
+    <meta name="DC.Relation" content="Has part {{ persistent_identifier_to_uri(pack.Persistent_Identifier.Identifier_Scheme, pack.Persistent_Identifier.Identifier) }}">
     <title>{{ title }} - Data Publication platform of Utrecht University</title>
 
     <link href="/static/css/bootstrap.min.css?v=1559637767" rel="stylesheet">

--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -12,7 +12,6 @@
     <meta name="DC.date" content="{{ publication_date }}" scheme="DCTERMS.W3CDTF">
     <meta name="DC.type" content="{{ datatype }}">
     <meta name="DC.identifier" content="{{ open_access_link }}">
-    <meta name="DC.Relation" content="Has part {{ persistent_identifier_to_uri(pack.Persistent_Identifier.Identifier_Scheme, pack.Persistent_Identifier.Identifier) }}">
     <title>{{ title }} - Data Publication platform of Utrecht University</title>
 
     <link href="/static/css/bootstrap.min.css?v=1559637767" rel="stylesheet">
@@ -358,7 +357,7 @@
                                 <label class="indented">Type of relation</label>
                             </div>
                             <div class="col-sm-10">
-                                <span property="dc:relation">{{ pack.Relation_Type }}</span>
+                                <span>{{ pack.Relation_Type }}</span>
                             </div>
                         </div>
 
@@ -368,7 +367,7 @@
                                 <label class="indented">Persistent Identifier</label>
                             </div>
                             <div class="col-sm-10">
-                                <span property="dc:identifier">
+                                <span property="dc:relation">
                                 <a href="{{ persistent_identifier_to_uri(pack.Persistent_Identifier.Identifier_Scheme, pack.Persistent_Identifier.Identifier) }}" target="_blank">
                                   {{ persistent_identifier_to_uri(pack.Persistent_Identifier.Identifier_Scheme, pack.Persistent_Identifier.Identifier) }}
                                 </a>


### PR DESCRIPTION
**Story: https://utrechtuniversity.atlassian.net/browse/YDA-5734**

Findable: FsF-F3-01M - Metadata contains a PID or URL which indicates the location of the downloadable data content

**Extra Material:**
https://zenodo.org/records/6461229