### PR TITLE
YDA-5783: fix logic for vault schemas

### DIFF
--- a/tools/update-schema-id.r
+++ b/tools/update-schema-id.r
@@ -50,7 +50,6 @@ def get_schema_collection(ctx, rods_zone, group_name, default_schema):
         # If not, fall back to default schema collection.
         # /tempZone/yoda/schemas/default/metadata.json
         schema_path = '/' + rods_zone + '/yoda/schemas/' + category
-        schema_coll = default_schema
 
         iter = genquery.row_iterator(
             "COLL_NAME",
@@ -59,9 +58,9 @@ def get_schema_collection(ctx, rods_zone, group_name, default_schema):
         )
 
         for _row in iter:
-            schema_coll = category  # As collection is present, the schema_collection can be assigned the category.
+            return category
 
-    return schema_coll
+    return default_schema
 
 
 def main(rule_args, callback, rei):


### PR DESCRIPTION
This fix implements additional logic for determining the active metadata schema of a vault group.

In addition to the existing behaviour (using the metadata schema of the matching deposit/research group), we now allow a schema_id AVU to be set on the vault group that overrides the metadata schema. Furthermore, if no vault schema_id AVU is set and no research/deposit group is found, we revert to the default metadata schema of the environment.

This ensures that metadata conversion can work on vault groups that no longer have a matching research/deposit group. If a standalone vault group has a non-default metadata schema, its metadata schema needs to be configured explicitly for it to be processed correctly by the schema transformation rules.