### PR TITLE
fix tests for data transfer page

### DIFF
--- a/tests/step_defs/ui/test_ui_data_transfer.py
+++ b/tests/step_defs/ui/test_ui_data_transfer.py
@@ -83,7 +83,7 @@ def ui_data_transfer_icommands_configuration_file_downloaded(browser, tmpdir, fo
 
 @when('user clicks on Gocommands tab')
 def ui_data_transfer_gocommands_tab(browser):
-    browser.find_by_text('Gocommands').click()
+    browser.find_by_text('GoCommands').click()
 
 
 @when("user clicks on the Gocommands docs page")


### PR DESCRIPTION
Just a quick fix for the tests because with the latest changes some of them did not work.

**Problem**
In the data_transfer.html file, the text "Gocommands" had been changed in "GoCommands".

**Solution**
Small change in the test_ui_data_transfer.py file, to search for "GoCommands" instead of "Gocommands" 