### PR TITLE
YDA 5718 add maintenance banner's UI Test

### DIFF
--- a/tests/features/ui/ui_admin.feature
+++ b/tests/features/ui/ui_admin.feature
@@ -1,50 +1,12 @@
 @ui
 Feature: Admin UI
-    Scenario Outline: Admin user sets up a default banner message
-        Given user <user> is logged in
-        When the user navigates to the admin page
-        And the user input banner text with message <message>
-        And the user <action> the checkbox to mark the banner as important
-        And the user click button <button>
-        And the user navigates to the home page
-        Then the banner display the message <message>
-        And the banner background color should be <color>
-    # Example 1 :Set an unimportant banner message
-    # Exampel 2 :Set an important banner message
-    Examples:
-        | user                | message             | action     | button     |color           |
-        | functionaladminpriv | Test banner message | unchecks   | Set Banner |text-bg-primary |
-        | functionaladminpriv | Test banner message | checks     | Set Banner |text-bg-danger  |
-
-    Scenario Outline: Admin user removes an exsting banner message
-        Given user <user> is logged in
-        And the banner display the message <message>
-        When the user navigates to the admin page
-        And the user click button <Remove Banner>
-        And the user navigates to the home page
-        Then the banner does not exist
-    Examples:
-        | user                | message             | Remove Banner        |
-        | functionaladminpriv | Test banner message | Remove Banner |
-
-    # Error scenarios
-    # 1. Input empty / long message
-
-    Scenario Outline: Admin user views banner setup options
-        Given user <user> is logged in
-        When the user navigates to the admin page
-        Then the banner setup option should be visible
-
-        Examples:
-            | user                |
-            | functionaladminpriv |
-
 
     Scenario Outline: Admin page view by admin users
         Given user <user> is logged in
         When the user navigates to the admin page
         Then the text Administration is shown
         And Administration option is available in the menu dropdown
+        And the banner setup option should be visible
 
         Examples:
             | user                |
@@ -61,3 +23,32 @@ Feature: Admin UI
         Examples:
             | user                |
             | researcher          | # Role: non-admin and Group: non-priv-group
+
+
+    Scenario Outline: Admin user sets up a default banner message
+        Given user <user> is logged in
+        When the user navigates to the admin page
+        And the user input banner text with message <message>
+        And the user <action> the checkbox to mark the banner as important
+        And the user click button <button>
+        And the user navigates to the home page
+        Then the banner display the message <message>
+        And the banner background color should be <color>
+    # Example 1 :Set an unimportant banner message
+    # Exampel 2 :Set an important banner message
+    Examples:
+        | user                | message             | action     | button     |color           |
+        | functionaladminpriv | Test banner message | unchecks   | Set Banner |text-bg-primary |
+        | functionaladminpriv | Test banner message | checks     | Set Banner |text-bg-danger  |
+
+
+    Scenario Outline: Admin user removes an exsting banner message
+        Given user <user> is logged in
+        And the banner display the message <message>
+        When the user navigates to the admin page
+        And the user click button <Remove Banner>
+        And the user navigates to the home page
+        Then the banner does not exist
+    Examples:
+        | user                | message             | Remove Banner |
+        | functionaladminpriv | Test banner message | Remove Banner |

--- a/tests/features/ui/ui_admin.feature
+++ b/tests/features/ui/ui_admin.feature
@@ -1,9 +1,48 @@
 @ui
 Feature: Admin UI
+    Scenario Outline: Admin user sets up a default banner message
+        Given user <user> is logged in
+        When the user navigates to the admin page
+        And the user input banner text with message <message>
+        And the user <action> the checkbox to mark the banner as important
+        And the user click button <button>
+        And the user navigates to the home page
+        Then the banner display the message <message>
+        And the banner background color should be <color>
+    # Example 1 :Set an unimportant banner message
+    # Exampel 2 :Set an important banner message
+    Examples:
+        | user                | message             | action     | button     |color           |
+        | functionaladminpriv | Test banner message | unchecks   | Set Banner |text-bg-primary |
+        | functionaladminpriv | Test banner message | checks     | Set Banner |text-bg-danger  |
+
+    Scenario Outline: Admin user removes an exsting banner message
+        Given user <user> is logged in
+        And the banner display the message <message>
+        When the user navigates to the admin page
+        And the user click button <Remove Banner>
+        And the user navigates to the home page
+        Then the banner does not exist
+    Examples:
+        | user                | message             | Remove Banner        |
+        | functionaladminpriv | Test banner message | Remove Banner |
+
+    # Error scenarios
+    # 1. Input empty / long message
+
+    Scenario Outline: Admin user views banner setup options
+        Given user <user> is logged in
+        When the user navigates to the admin page
+        Then the banner setup option should be visible
+
+        Examples:
+            | user                |
+            | functionaladminpriv |
+
 
     Scenario Outline: Admin page view by admin users
         Given user <user> is logged in
-        When user opens link to admin page
+        When the user navigates to the admin page
         Then the text Administration is shown
         And Administration option is available in the menu dropdown
 
@@ -15,7 +54,7 @@ Feature: Admin UI
 
     Scenario Outline: Admin page view by non-admin user
         Given user <user> is logged in
-        When user opens link to admin page
+        When the user navigates to the admin page
         Then the text Access forbidden is shown
         And Administration option is not available in the menu dropdown
 

--- a/tests/step_defs/ui/test_ui_admin.py
+++ b/tests/step_defs/ui/test_ui_admin.py
@@ -7,17 +7,25 @@ __license__ = "GPLv3, see LICENSE"
 from pytest_bdd import (
     parsers,
     scenarios,
+    given,
     then,
     when,
 )
+from conftest import roles
 
+import time  #TODO: Remove it later
 from conftest import portal_url
 
 scenarios("../../features/ui/ui_admin.feature")
 
+@when("the user navigates to the home page")
+def ui_admin_home_access(browser):
+    url = "{}/".format(portal_url)
+    browser.visit(url)
 
-@when(parsers.parse("user opens link to admin page"))
+@when("the user navigates to the admin page")
 def ui_admin_access(browser):
+    time.sleep(10)
     url = "{}/admin".format(portal_url)
     browser.visit(url)
 
@@ -46,3 +54,67 @@ def ui_admin_administration_dropdown_not_present(browser):
 @then("the text Access forbidden is shown")
 def ui_admin_access_forbidden(browser):
     assert browser.is_text_present("Access forbidden")
+
+
+@then("the banner setup option should be visible")
+def ui_admin_banner_option_prensent(browser):
+    assert browser.is_text_present("Set maintenance banner"), "Banner title not found on the page"
+    assert browser.find_by_name("banner").visible, "Textarea for banner message not found on the page"
+    assert browser.find_by_id("importance").visible, "Checkbox for 'Mark as Important' not found on the page"
+    assert browser.find_by_css("button[name='Set Banner']").visible, "Button to set the banner not found on the page"
+    assert browser.find_by_css("button[name='Remove Banner']").visible, "Button to remove the banner not found on the page"
+
+@given(parsers.parse("an authenticated user {user} in 'priv-admin' group"),target_fixture="user")
+def ui_admin_user_authenticated_in_priv_group(user):
+    assert user in roles
+    return user
+
+@given(parsers.parse("{user} is a member of {group_name} group"))
+def ui_admin_user_in_group(user,group_name):
+    print("user",user)
+    print("group",group_name)
+    print("role group",roles[user])
+
+# TODO: New from here
+
+@when(parsers.parse("the user input banner text with message {message}"))
+def ui_admin_input_banner_msg(browser,message):
+    browser.fill("banner",message)
+
+@when(parsers.parse("the user {action} the checkbox to mark the banner as important"))
+def ui_admin_control_importance(browser, action):
+    if action == "checks":
+        browser.check("importance")
+    elif action == "unchecks":
+        browser.uncheck("importance")
+    else:
+        raise ValueError(f"Unsupported action: {action}.")
+
+@when(parsers.parse("the user click button {button}"))
+def ui_admin_click_button(browser,button):
+    browser.find_by_name(button).first.click()
+
+@given(parsers.parse("the banner display the message {message}"))
+@then(parsers.parse("the banner display the message {message}"))
+def ui_admin_display_banner(browser,message):
+    assert browser.is_element_present_by_name('banner head')
+    assert browser.is_text_present(message)
+
+@then("the banner does not exist")
+def ui_admin_display_banner(browser):
+    assert browser.is_element_not_present_by_name('banner head')
+
+@then(parsers.parse("the banner background color should be {color}"))
+def ui_admin_display_banner_color(browser,color):
+    element = browser.find_by_css('div.non-production[role="alert"]').first
+    print("elemetn:",element)
+    #browser.find_by_css('.text-bg-primary')
+    # Fetch the class attribute
+    class_attribute = element['class']
+    print("class_attribute:",class_attribute)
+
+    is_color_present = color in class_attribute.split()
+    print("is_color_present:",is_color_present)
+
+    # Assert or print out the result
+    assert is_color_present

--- a/tests/step_defs/ui/test_ui_admin.py
+++ b/tests/step_defs/ui/test_ui_admin.py
@@ -5,9 +5,9 @@ __copyright__ = "Copyright (c) 2024, Utrecht University"
 __license__ = "GPLv3, see LICENSE"
 
 from pytest_bdd import (
+    given,
     parsers,
     scenarios,
-    given,
     then,
     when,
 )

--- a/tests/step_defs/ui/test_ui_admin.py
+++ b/tests/step_defs/ui/test_ui_admin.py
@@ -12,7 +12,6 @@ from pytest_bdd import (
     when,
 )
 
-import time  #TODO: Remove it later
 from conftest import portal_url
 
 scenarios("../../features/ui/ui_admin.feature")
@@ -33,7 +32,6 @@ def ui_admin_home_access(browser):
 
 @when("the user navigates to the admin page")
 def ui_admin_access(browser):
-    time.sleep(10)  #TODO: Remove it
     url = "{}/admin".format(portal_url)
     browser.visit(url)
 
@@ -50,7 +48,7 @@ def ui_admin_control_importance(browser, action):
     elif action == "unchecks":
         browser.uncheck("importance")
     else:
-        raise ValueError(f"Unsupported action: {action}.")
+        raise ValueError("Unsupported action.")
 
 
 @when(parsers.parse("the user click button {button}"))
@@ -101,12 +99,5 @@ def ui_admin_remove_banner(browser):
 @then(parsers.parse("the banner background color should be {color}"))
 def ui_admin_display_banner_color(browser, color):
     element = browser.find_by_css('div.non-production[role="alert"]').first
-    print("elemetn:", element)
-    class_attribute = element['class']
-    print("class_attribute:", class_attribute)
-
-    is_color_present = color in class_attribute.split()
-    print("is_color_present:", is_color_present)
-
-    # Assert or print out the result
+    is_color_present = color in element['class'].split()
     assert is_color_present

--- a/tests/step_defs/ui/test_ui_admin.py
+++ b/tests/step_defs/ui/test_ui_admin.py
@@ -11,23 +11,51 @@ from pytest_bdd import (
     then,
     when,
 )
-from conftest import roles
 
 import time  #TODO: Remove it later
 from conftest import portal_url
 
 scenarios("../../features/ui/ui_admin.feature")
 
+
+@given(parsers.parse("the banner display the message {message}"))
+@then(parsers.parse("the banner display the message {message}"))
+def ui_admin_display_banner(browser, message):
+    assert browser.is_element_present_by_name('banner head')
+    assert browser.is_text_present(message)
+
+
 @when("the user navigates to the home page")
 def ui_admin_home_access(browser):
     url = "{}/".format(portal_url)
     browser.visit(url)
 
+
 @when("the user navigates to the admin page")
 def ui_admin_access(browser):
-    time.sleep(10)
+    time.sleep(10)  #TODO: Remove it
     url = "{}/admin".format(portal_url)
     browser.visit(url)
+
+
+@when(parsers.parse("the user input banner text with message {message}"))
+def ui_admin_input_banner_msg(browser, message):
+    browser.fill("banner", message)
+
+
+@when(parsers.parse("the user {action} the checkbox to mark the banner as important"))
+def ui_admin_control_importance(browser, action):
+    if action == "checks":
+        browser.check("importance")
+    elif action == "unchecks":
+        browser.uncheck("importance")
+    else:
+        raise ValueError(f"Unsupported action: {action}.")
+
+
+@when(parsers.parse("the user click button {button}"))
+def ui_admin_click_button(browser, button):
+    browser.find_by_name(button).first.click()
 
 
 @then("the text Administration is shown")
@@ -64,57 +92,21 @@ def ui_admin_banner_option_prensent(browser):
     assert browser.find_by_css("button[name='Set Banner']").visible, "Button to set the banner not found on the page"
     assert browser.find_by_css("button[name='Remove Banner']").visible, "Button to remove the banner not found on the page"
 
-@given(parsers.parse("an authenticated user {user} in 'priv-admin' group"),target_fixture="user")
-def ui_admin_user_authenticated_in_priv_group(user):
-    assert user in roles
-    return user
-
-@given(parsers.parse("{user} is a member of {group_name} group"))
-def ui_admin_user_in_group(user,group_name):
-    print("user",user)
-    print("group",group_name)
-    print("role group",roles[user])
-
-# TODO: New from here
-
-@when(parsers.parse("the user input banner text with message {message}"))
-def ui_admin_input_banner_msg(browser,message):
-    browser.fill("banner",message)
-
-@when(parsers.parse("the user {action} the checkbox to mark the banner as important"))
-def ui_admin_control_importance(browser, action):
-    if action == "checks":
-        browser.check("importance")
-    elif action == "unchecks":
-        browser.uncheck("importance")
-    else:
-        raise ValueError(f"Unsupported action: {action}.")
-
-@when(parsers.parse("the user click button {button}"))
-def ui_admin_click_button(browser,button):
-    browser.find_by_name(button).first.click()
-
-@given(parsers.parse("the banner display the message {message}"))
-@then(parsers.parse("the banner display the message {message}"))
-def ui_admin_display_banner(browser,message):
-    assert browser.is_element_present_by_name('banner head')
-    assert browser.is_text_present(message)
 
 @then("the banner does not exist")
-def ui_admin_display_banner(browser):
+def ui_admin_remove_banner(browser):
     assert browser.is_element_not_present_by_name('banner head')
 
+
 @then(parsers.parse("the banner background color should be {color}"))
-def ui_admin_display_banner_color(browser,color):
+def ui_admin_display_banner_color(browser, color):
     element = browser.find_by_css('div.non-production[role="alert"]').first
-    print("elemetn:",element)
-    #browser.find_by_css('.text-bg-primary')
-    # Fetch the class attribute
+    print("elemetn:", element)
     class_attribute = element['class']
-    print("class_attribute:",class_attribute)
+    print("class_attribute:", class_attribute)
 
     is_color_present = color in class_attribute.split()
-    print("is_color_present:",is_color_present)
+    print("is_color_present:", is_color_present)
 
     # Assert or print out the result
     assert is_color_present


### PR DESCRIPTION
1. Improve the scenario that when the user navigates to the admin page, "set maintenance banner" options are present.
3. Add a new scenario that the user sets up a banner message with/without marking it as important.
4. Add a new scenario that the user removes the existing banner.