### PR TITLE
Yda 5760 fix statistics

### DIFF
--- a/resources.py
+++ b/resources.py
@@ -72,13 +72,10 @@ def api_resource_browse_group_data(ctx,
         group_list.append([groupname, data_size])
 
     # Sort the list as requested by user
-    sort_key = lambda x: x[0]
-    if sort_on == 'size':
-        sort_key = lambda x: x[1][-1]
     sort_reverse = False
     if sort_order == 'desc':
         sort_reverse = True
-    group_list.sort(key=sort_key, reverse=sort_reverse)
+    group_list.sort(key=lambda x: x[1][-1] if sort_on == 'size' else x[0], reverse=sort_reverse)
 
     # Only at this point we have the list in correct shape/order and can the limit and offset be applied
     # Format for datatables in frontend throughout yoda

--- a/resources.py
+++ b/resources.py
@@ -72,13 +72,13 @@ def api_resource_browse_group_data(ctx,
         group_list.append([groupname, data_size])
 
     # Sort the list as requested by user
-    sort_key = 0
+    sort_key = lambda x: x[0]
     if sort_on == 'size':
-        sort_key = 1
+        sort_key = lambda x: x[1][-1]
     sort_reverse = False
     if sort_order == 'desc':
         sort_reverse = True
-    group_list.sort(key=lambda x: x[sort_key], reverse=sort_reverse)
+    group_list.sort(key=sort_key, reverse=sort_reverse)
 
     # Only at this point we have the list in correct shape/order and can the limit and offset be applied
     # Format for datatables in frontend throughout yoda


### PR DESCRIPTION
https://utrechtuniversity.atlassian.net/browse/YDA-5760

**Description**
When user tries to sort groups by size in the Statistics module, the correct sorting order is not followed.

**Problem**
In api_resource_browse_group_data function of resources.py, data_size was a list of four integers. We sorted by size using the list of 4 integers.

**Solution**
Change the sorting mechanism in resources.py. In api_resource_browse_group_data function we change the sorting to use the last integer of the list