### PR TITLE
YDA-5810 fix rev cleanup handling removed data

### DIFF
--- a/unit-tests/test_revisions.py
+++ b/unit-tests/test_revisions.py
@@ -64,43 +64,73 @@ class RevisionTest(TestCase):
         # Tests total length of all buckets in seconds; equivalent to roughly 29 weeks.
         self.assertEqual(strategy.get_total_bucket_timespan(), 17755200)
 
-    def test_revision_cleanup_prefilter(self):
+    def test_revision_cleanup_prefilter_empty(self):
         empty_input = []
-        empty_output = revision_cleanup_prefilter(None, empty_input, "B", False)
+        empty_output = revision_cleanup_prefilter(None, empty_input, "B", dict(), False)
         self.assertEqual(empty_output, [])
+
+    def test_revision_cleanup_prefilter_single_exists(self):
         single_input = [[(1, 123, "/foo/bar/baz")]]
-        single_output = revision_cleanup_prefilter(None, single_input, "B", False)
+        exists_dict = {"/foo/bar/baz": True}
+        single_output = revision_cleanup_prefilter(None, single_input, "B", exists_dict, False)
         self.assertEqual(single_output, [])  # Does not exceed min. bucket size for strategy B
+
+    def test_revision_cleanup_prefilter_single_doesnotexist(self):
+        single_input = [[(1, 123, "/foo/bar/baz")]]
+        exists_dict = {"/foo/bar/baz": False}
+        single_output = revision_cleanup_prefilter(None, single_input, "B", exists_dict, False)
+        # Do not prefilter if versioned data object no longer exists
+        self.assertEqual(single_output, single_input)
+
+    def test_revision_cleanup_prefilter_two_exists(self):
         two_input = [[(1, 123, "/foo/bar/baz"), (2, 234, "/foo/bar/baz")]]
-        two_output = revision_cleanup_prefilter(None, two_input, "B", False)
+        exists_dict = {"/foo/bar/baz": True}
+        two_output = revision_cleanup_prefilter(None, two_input, "B", exists_dict, False)
         # Does not exceed min. bucket size for strategy B
         # But more than 1 revision (so cannot prefilter, because
         # revisions could be outside defined buckets)
         self.assertEqual(two_output, two_input)
+
+    def test_revision_cleanup_prefilter_two_doesnotexist(self):
+        exists_dict = {"/foo/bar/baz": False}
+        two_input = [[(1, 123, "/foo/bar/baz"), (2, 234, "/foo/bar/baz")]]
+        two_output = revision_cleanup_prefilter(None, two_input, "B", exists_dict, False)
+        # Do not prefilter if versioned data object no longer exists
+        self.assertEqual(two_output, two_input)
+
+    def test_revision_cleanup_prefilter_three(self):
         three_input = [[(1, 123, "/foo/bar/baz"), (2, 234, "/foo/bar/baz"), (3, 345, "/foo/bar/baz")]]
-        three_output = revision_cleanup_prefilter(None, three_input, "B", False)
+        exists_dict = {"/foo/bar/baz": True}
+        three_output = revision_cleanup_prefilter(None, three_input, "B", exists_dict, False)
         self.assertEqual(three_output, three_input)  # Exceeds min. bucket size for strategy B
 
     def test_revision_deletion_candidates_empty(self):
         dummy_time = 1000000000
         revision_strategy = get_revision_strategy("B")
         revisions = []
-        output = get_deletion_candidates(None, revision_strategy, revisions, dummy_time, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, dummy_time, True, False)
         self.assertEqual(output, [])
 
-    def test_revision_deletion_candidates_1_bucket_no_exceed(self):
+    def test_revision_deletion_candidates_1_bucket_no_exceed_exists(self):
         dummy_time = 1000000000
         revision_strategy = get_revision_strategy("B")
         revisions = [(1, dummy_time - 60, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [])
+
+    def test_revision_deletion_candidates_1_bucket_no_exceed_doesnotexist(self):
+        dummy_time = 1000000000
+        revision_strategy = get_revision_strategy("B")
+        revisions = [(1, dummy_time - 60, "/foo/bar/baz")]
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False, False)
+        self.assertEqual(output, [1])
 
     def test_revision_deletion_candidates_2_bucket_no_exceed(self):
         dummy_time = 1000000000
         revision_strategy = get_revision_strategy("B")
         revisions = [(1, dummy_time - 60, "/foo/bar/baz"),
                      (2, dummy_time - 120, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [])
 
     def test_revision_deletion_candidates_2_multi_bucket_no_exceed(self):
@@ -108,7 +138,7 @@ class RevisionTest(TestCase):
         revision_strategy = get_revision_strategy("B")
         revisions = [(1, dummy_time - 60, "/foo/bar/baz"),
                      (2, dummy_time - 13 * 3600, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [])
 
     def test_revision_deletion_candidates_4_multi_bucket_no_exceed(self):
@@ -118,17 +148,26 @@ class RevisionTest(TestCase):
                      (2, dummy_time - 120, "/foo/bar/baz"),
                      (3, dummy_time - 3600 * 16, "/foo/bar/baz"),
                      (4, dummy_time - 3600 * 17, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [])
 
-    def test_revision_deletion_candidates_3_bucket_exceed(self):
+    def test_revision_deletion_candidates_3_bucket_exceed_exists(self):
         dummy_time = 1000000000
         revision_strategy = get_revision_strategy("B")
         revisions = [(1, dummy_time - 60, "/foo/bar/baz"),
                      (2, dummy_time - 120, "/foo/bar/baz"),
                      (3, dummy_time - 180, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [2])
+
+    def test_revision_deletion_candidates_3_bucket_exceed_doesnotexist(self):
+        dummy_time = 1000000000
+        revision_strategy = get_revision_strategy("B")
+        revisions = [(1, dummy_time - 60, "/foo/bar/baz"),
+                     (2, dummy_time - 120, "/foo/bar/baz"),
+                     (3, dummy_time - 180, "/foo/bar/baz")]
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False, False)
+        self.assertEqual(output, [1, 2, 3])
 
     def test_revision_deletion_candidates_6_buckets_exceed(self):
         dummy_time = 1000000000
@@ -139,14 +178,14 @@ class RevisionTest(TestCase):
                      (4, dummy_time - 3600 * 16 - 60, "/foo/bar/baz"),
                      (5, dummy_time - 3600 * 16 - 120, "/foo/bar/baz"),
                      (6, dummy_time - 3600 * 16 - 180, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [2, 5])
 
     def test_revision_deletion_1_before_buckets(self):
         dummy_time = 1000000000
         revision_strategy = get_revision_strategy("B")
         revisions = [(1, dummy_time - 365 * 24 * 3600, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [])
 
     def test_revision_deletion_1_bucket_1_before(self):
@@ -154,7 +193,7 @@ class RevisionTest(TestCase):
         revision_strategy = get_revision_strategy("B")
         revisions = [(1, dummy_time - 60, "/foo/bar/baz"),
                      (2, dummy_time - 365 * 24 * 3600, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [2])
 
     def test_revision_deletion_1_bucket_2_before(self):
@@ -163,7 +202,7 @@ class RevisionTest(TestCase):
         revisions = [(1, dummy_time - 60, "/foo/bar/baz"),
                      (2, dummy_time - 365 * 24 * 3600 - 60, "/foo/bar/baz"),
                      (3, dummy_time - 365 * 24 * 3600 - 90, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [2, 3])
 
     def test_revision_deletion_3_before_buckets(self):
@@ -172,5 +211,5 @@ class RevisionTest(TestCase):
         revisions = [(1, dummy_time - 365 * 24 * 3600 - 60, "/foo/bar/baz"),
                      (2, dummy_time - 365 * 24 * 3600 - 120, "/foo/bar/baz"),
                      (3, dummy_time - 365 * 24 * 3600 - 180, "/foo/bar/baz")]
-        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, False)
+        output = get_deletion_candidates(None, revision_strategy, revisions, 1000000000, True, False)
         self.assertEqual(output, [2, 3])


### PR DESCRIPTION
Update revision logic to remove revisions of versioned data objects that no longer exist in the revision cleanup process.