### PR TITLE
YDA-5835: fix zone selection in transform script

### DIFF
--- a/tools/transform-existing-publications.r
+++ b/tools/transform-existing-publications.r
@@ -15,13 +15,13 @@ def main(rule_args, callback, rei):
     # Changing yoda prefix -> version
     iter = genquery.row_iterator(
         "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
-        "USER_ZONE = '{}' AND META_COLL_ATTR_NAME LIKE 'org_publication_yoda%'".format(zone),
+        "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME LIKE 'org_publication_yoda%'".format(zone),
         genquery.AS_TUPLE,
         callback) 
 
     iter2 = genquery.row_iterator(
         "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
-        "USER_ZONE = '{}' AND META_COLL_ATTR_NAME in ('org_publication_DOIAvailable', 'org_publication_DOIMinted')".format(zone),
+        "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME in ('org_publication_DOIAvailable', 'org_publication_DOIMinted')".format(zone),
         genquery.AS_TUPLE,
         callback) 
 


### PR DESCRIPTION
In the script for transforming publication metadata to support base DOIs, adjust the query condition for selecting the zone of a collection.

Selecting on USER_ZONE does not reliably return all data package collections in the zone. We need to either check the zone of the collection itself, or check the beginning of the collection name to select its zone.