### PR TITLE
Yda 5775 fix data request is not allowed internal error

### DIFF
--- a/datarequest.py
+++ b/datarequest.py
@@ -501,6 +501,7 @@ def datarequest_owner_get(ctx, request_id):
     except Exception:
         return None
 
+
 def datarequest_is_reviewer(ctx, request_id, pending=False):
     """Check if a user is assigned as reviewer to a data request
 

--- a/datarequest.py
+++ b/datarequest.py
@@ -1053,7 +1053,7 @@ def api_datarequest_get(ctx, request_id):
         datarequest_type = type_get(ctx, request_id).value
     except Exception:
         return {'requestStatus': 'forbidden'}
-    
+
     # Get request status
     datarequest_status = status_get(ctx, request_id).value
 

--- a/datarequest.py
+++ b/datarequest.py
@@ -1051,8 +1051,8 @@ def api_datarequest_get(ctx, request_id):
     # Get request type
     try:
         datarequest_type = type_get(ctx, request_id).value
-    except Exception:
-        return {'requestStatus': 'forbidden'}
+    except Exception as e:
+        return api.Error("datarequest_type_fail", "Error: {}".format(e))
 
     # Get request status
     datarequest_status = status_get(ctx, request_id).value

--- a/datarequest.py
+++ b/datarequest.py
@@ -1049,8 +1049,11 @@ def api_datarequest_get(ctx, request_id):
     datarequest_action_permitted(ctx, request_id, ["PM", "DM", "DAC", "OWN"], None)
 
     # Get request type
-    datarequest_type = type_get(ctx, request_id).value
-
+    try:
+        datarequest_type = type_get(ctx, request_id).value
+    except Exception:
+        return {'requestStatus': 'forbidden'}
+    
     # Get request status
     datarequest_status = status_get(ctx, request_id).value
 

--- a/datarequest.py
+++ b/datarequest.py
@@ -496,8 +496,10 @@ def datarequest_owner_get(ctx, request_id):
                                       + JSON_EXT)
 
     # Get and return data request owner
-    return jsonutil.read(ctx, file_path)['owner']
-
+    try:
+        return jsonutil.read(ctx, file_path)['owner']
+    except Exception:
+        return None
 
 def datarequest_is_reviewer(ctx, request_id, pending=False):
     """Check if a user is assigned as reviewer to a data request


### PR DESCRIPTION
In Yoda 1.9.3, navigating to a data request that the present user does not have access to results in an internal error being shown.

Now, this is fixed and shows 

![image](https://github.com/user-attachments/assets/25ba0153-6f61-4b9f-b5d0-65c924eb05eb)