### PR TITLE
YDA-5863: fix log messages schema transformation

### DIFF
--- a/schema_transformation.py
+++ b/schema_transformation.py
@@ -141,10 +141,10 @@ def copy_acls_from_parent(ctx, path, recursive_flag):
             log.write(ctx, "iiCopyACLsFromParent: granting own to <" + user_name + "> on <" + path + "> with recursiveFlag <" + recursive_flag + ">")
             msi.set_acl(ctx, recursive_flag, "own", user_name, path)
         elif access_name == "read object":
-            log.write(ctx, "iiCopyACLsFromParent: granting own to <" + user_name + "> on <" + path + "> with recursiveFlag <" + recursive_flag + ">")
+            log.write(ctx, "iiCopyACLsFromParent: granting read to <" + user_name + "> on <" + path + "> with recursiveFlag <" + recursive_flag + ">")
             msi.set_acl(ctx, recursive_flag, "read", user_name, path)
         elif access_name == "modify object":
-            log.write(ctx, "iiCopyACLsFromParent: granting own to <" + user_name + "> on <" + path + "> with recursiveFlag <" + recursive_flag + ">")
+            log.write(ctx, "iiCopyACLsFromParent: granting write to <" + user_name + "> on <" + path + "> with recursiveFlag <" + recursive_flag + ">")
             msi.set_acl(ctx, recursive_flag, "write", user_name, path)
 
 


### PR DESCRIPTION
The log messages for copying ACLs did not match the actions that the system was performing.