### PR TITLE
YDA-5864: ignore deleted users in schema transf.

### DIFF
--- a/schema_transformation.py
+++ b/schema_transformation.py
@@ -137,6 +137,11 @@ def copy_acls_from_parent(ctx, path, recursive_flag):
 
         user_name = user.name_from_id(ctx, user_id)
 
+        # iRODS keeps ACLs for deleted users in the iCAT database (https://github.com/irods/irods/issues/7778),
+        # so we need to skip ACLs referring to users that no longer exist.
+        if user_name == "":
+            continue
+
         if access_name == "own":
             log.write(ctx, "iiCopyACLsFromParent: granting own to <" + user_name + "> on <" + path + "> with recursiveFlag <" + recursive_flag + ">")
             msi.set_acl(ctx, recursive_flag, "own", user_name, path)


### PR DESCRIPTION
In the schema transformation code, ignore ACLs of non-existent users when copying ACLs from a parent. This is needed because iRODS keeps ACLs referring to deleted users / groups around in the database (see https://github.com/irods/irods/issues/7778).