### PR TITLE
Add configured value for dap expiry date notification

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -481,9 +481,10 @@ def rule_process_data_access_token_expiry(ctx):
         exp_time = datetime.strptime(token['exp_time'], '%Y-%m-%d %H:%M:%S.%f')
         date_exp_time = exp_time - timedelta(hours=config.token_expiration_notification)
         r = relativedelta.relativedelta(date_exp_time, datetime.now().date())
+        total_hours = r.years * 12 * 30 * 24 + r.months * 30 * 24 + r.days * 24
 
-        # Send notification if token expires in less than a day.
-        if r.years == 0 and r.months == 0 and r.days <= 1:
+        # Send notification if token expires in less than total hours.
+        if total_hours <= config.token_expiration_notification:
             actor = 'system'
             target = str(user.from_str(ctx, token['user']))
             message = "Data access password with label <{}> is expiring".format(token["label"])

--- a/notifications.py
+++ b/notifications.py
@@ -481,7 +481,7 @@ def rule_process_data_access_token_expiry(ctx):
         exp_time = datetime.strptime(token['exp_time'], '%Y-%m-%d %H:%M:%S.%f')
         date_exp_time = exp_time - timedelta(hours=config.token_expiration_notification)
         r = relativedelta.relativedelta(date_exp_time, datetime.now().date())
-        total_hours = r.years * 12 * 30 * 24 + r.months * 30 * 24 + r.days * 24
+        total_hours = r.years * 12 * 30 * 24 + r.months * 30 * 24 + r.days * 24 + r.hours
 
         # Send notification if token expires in less than total hours.
         if total_hours <= config.token_expiration_notification:

--- a/notifications.py
+++ b/notifications.py
@@ -483,7 +483,7 @@ def rule_process_data_access_token_expiry(ctx):
         r = relativedelta.relativedelta(date_exp_time, datetime.now().date())
         total_hours = r.years * 12 * 30 * 24 + r.months * 30 * 24 + r.days * 24 + r.hours
 
-        # Send notification if token expires in less than total hours.
+        # Send notification if token expires in less than configured hours.
         if total_hours <= config.token_expiration_notification:
             actor = 'system'
             target = str(user.from_str(ctx, token['user']))


### PR DESCRIPTION
**Problem:**

In the Yoda 1.10 development branch, we have a setting to control how many hours before expiry to send DAP expiry notifications:

 [yoda/docs/administration/configuring-yoda.md at 32b65a5edfed6ed988213efbe77e269c6c60ff96 · UtrechtUniversity/yoda](https://github.com/UtrechtUniversity/yoda/blob/32b65a5edfed6ed988213efbe77e269c6c60ff96/docs/administration/configuring-yoda.md?plain=1#L412) 

However, it seems that the ruleset uses a hard-coded value rather than the configured value:

 [yoda-ruleset/notifications.py at fdc13977d90c983c03684bc6ea038d50c6f68643 · UtrechtUniversity/yoda-ruleset](https://github.com/UtrechtUniversity/yoda-ruleset/blob/fdc13977d90c983c03684bc6ea038d50c6f68643/notifications.py#L486)  . 

It does disable notifications if expiry is set to 0 hours, but that’s not documented in the configuration docs.

**Outcome:**
Now, it works, When the expiration time is less than the configured one, it notifies the user in the notifications module
