### PR TITLE
YDA-5871: limit returned groups in group data

### DIFF
--- a/groups.py
+++ b/groups.py
@@ -348,8 +348,14 @@ def api_group_data(ctx):
 
     :param ctx: Combined type of a ctx and rei struct
 
-    :returns: Group hierarchy, user type and user zone
+    :returns: Group hierarchy, user type and user zone. Only group types managed
+              by the group manager are included.
     """
+    return (internal_api_group_data(ctx))
+
+
+def internal_api_group_data(ctx):
+    # This is the entry point for integration tests against api_group_data
     if user.is_admin(ctx):
         groups = getGroupsData(ctx)
     else:
@@ -360,6 +366,10 @@ def api_group_data(ctx):
 
         # Filter groups (only return groups user is part of), convert to json and write to stdout.
         groups = list(filter(lambda group: full_name in group['read'] + group['members'] or group['category'] in categories, groups))
+
+    # Only process group types managed via group manager
+    managed_prefixes = ("deposit-", "research-", "grp-", "datamanager-", "datarequests-", "intake-")
+    groups = list(filter(lambda group: group['name'].startswith(managed_prefixes), groups))
 
     # Sort groups on name.
     groups = sorted(groups, key=lambda d: d['name'])

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -15,6 +15,7 @@ import uuid
 
 import data_access_token
 import folder
+import groups
 import schema
 from util import avu, collection, config, constants, data_object, group, log, msi, resource, rule, user
 
@@ -140,6 +141,28 @@ def _test_folder_set_get_last_run(ctx):
     found, last_run = folder.get_last_run_time(ctx, tmp_coll)
     collection.remove(ctx, tmp_coll)
     return result, found, last_run
+
+
+def _test_groups_data(ctx):
+    test_vaultgroup = "vault-default-3"
+    ctx.msi_add_avu('-u', test_vaultgroup, "schema_id", "default-3", "")
+    groups_data = groups.internal_api_group_data(ctx)
+    avu.rmw_from_group(ctx, test_vaultgroup, "schema_id", "default-3", "")
+    group_names = [group
+                   for catdata in groups_data['group_hierarchy'].values()
+                   for subcatdata in catdata.values()
+                   for group in subcatdata]
+    # We are checking here that the function still works if we have a
+    # vault group with a group attribute, that the vault group is not
+    # returned (since vault groups are not managed via the group manager
+    # module), and that data is returned for group manager managed groups.
+    return ("research-default-3" in group_names
+            and "datarequests-research-datamanagers" in group_names
+            and "grp-vault-test" in group_names
+            and "intake-test2" in group_names
+            and "deposit-pilot" in group_names
+            and "datamanager-test-automation" in group_names
+            and "vault-default-3" not in group_names)
 
 
 def _test_schema_active_schema_deposit_from_default(ctx):
@@ -387,6 +410,9 @@ basic_integration_tests = [
     {"name":  "folder.determine_new_vault_target.invalid",
      "test": lambda ctx: folder.determine_new_vault_target(ctx, "/tempZone/home/not-research-group-not-exist/folder-not-exist"),
      "check": lambda x: x == ""},
+    {"name":  "groups.getGroupsData",
+     "test": lambda ctx: _test_groups_data(ctx),
+     "check": lambda x: x},
     {"name": "groups.rule_group_expiration_date_validate.1",
      "test": lambda ctx: ctx.rule_group_expiration_date_validate("", ""),
      "check": lambda x: x['arguments'][1] == 'true'},


### PR DESCRIPTION
When collecting group data for the group manager, collect only data for groups managed by the group manager. This prevents metadata on vault groups, in particular schema_id override AVUs (see YDA-5783), from breaking the group manager. More generally, it prevents the group manager from breaking because of group data for groups that are not managed by the group manager.