### PR TITLE
YDA-5859: publication failure due to inconsistent validation of creator affiliation

### DIFF
--- a/json_datacite.py
+++ b/json_datacite.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Functions for transforming Yoda JSON to DataCite 4.4 JSON."""
 
-__copyright__ = 'Copyright (c) 2019-2023, Utrecht University'
+__copyright__ = 'Copyright (c) 2019-2024, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 from dateutil import parser
@@ -218,13 +218,18 @@ def get_funders(combi):
 
 
 def get_creators(combi):
-    """Return creator information in datacite format."""
+    """Return creator information in DataCite format.
+
+    :param combi: Combined JSON file that holds both user and system metadata
+
+    :returns: JSON element with creators in DataCite format
+    """
     all_creators = []
 
     for creator in combi.get('Creator', []):
         affiliations = []
         for aff in creator.get('Affiliation', []):
-            if isinstance(aff, dict):
+            if isinstance(aff, dict) and len(aff) > 0:
                 if "Affiliation_Identifier" in aff and len(aff["Affiliation_Identifier"]):
                     affiliations.append({"name": aff['Affiliation_Name'],
                                          "affiliationIdentifier": '{}'.format(aff['Affiliation_Identifier']),
@@ -255,14 +260,14 @@ def get_contributors(combi):
 
     :param combi: Combined JSON file that holds both user and system metadata
 
-    :returns: XML element with contributors in DataCite format
+    :returns: JSON element with contributors in DataCite format
     """
     all = []
     # 1) Contributor
     for person in combi.get('Contributor', []):
         affiliations = []
         for aff in person.get('Affiliation', []):
-            if isinstance(aff, dict) and len(aff):
+            if isinstance(aff, dict) and len(aff) > 0:
                 if "Affiliation_Identifier" in aff and len(aff["Affiliation_Identifier"]):
                     affiliations.append({"name": aff['Affiliation_Name'],
                                          "affiliationIdentifier": '{}'.format(aff['Affiliation_Identifier']),

--- a/meta_form.py
+++ b/meta_form.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """JSON metadata form handling."""
 
-__copyright__ = 'Copyright (c) 2019-2022, Utrecht University'
+__copyright__ = 'Copyright (c) 2019-2024, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import re
@@ -296,7 +296,6 @@ def save(ctx, coll, metadata):
     is_vault = space is pathutil.Space.VAULT
     if is_vault:
         # It's a vault path - set up a staging area in the datamanager collection.
-
         ret = ctx.iiDatamanagerGroupFromVaultGroup(group, '')
         datamanager_group = ret['arguments'][1]
         if datamanager_group == '':
@@ -311,6 +310,9 @@ def save(ctx, coll, metadata):
 
         # Use staging area instead of trying to write to the vault directly.
         json_path = '{}/{}'.format(tmp_coll, constants.IIJSONMETADATA)
+
+    # Remove empty objects from metadata.
+    metadata = misc.remove_empty_objects(metadata)
 
     # Add metadata schema id to JSON.
     meta.metadata_set_schema_id(metadata, schema_.get_active_schema_id(ctx, json_path))

--- a/unit-tests/test_util_misc.py
+++ b/unit-tests/test_util_misc.py
@@ -54,10 +54,10 @@ class UtilMiscTest(TestCase):
 
     def test_remove_empty_objects(self):
         d = OrderedDict({"key1": None, "key2": "", "key3": {}, "key4": []})
-        self.assertEqual(remove_empty_objects(d), OrderedDict({}))
+        self.assertDictEqual(remove_empty_objects(d), OrderedDict({}))
         d = OrderedDict({"key1": "value1", "key2": {"key1": None, "key2": "", "key3": {}, "key4": []}})
-        self.assertEqual(remove_empty_objects(d), OrderedDict({"key1": "value1"}))
+        self.assertDictEqual(remove_empty_objects(d), OrderedDict({"key1": "value1"}))
         d = OrderedDict({"key1": "value1", "key2": {"key1": None, "key2": "", "key3": {}, "key4": [], "key5": "value5"}})
-        self.assertEqual(remove_empty_objects(d), OrderedDict({"key1": "value1", "key2": {"key5": "value5"}}))
+        self.assertDictEqual(remove_empty_objects(d), OrderedDict({"key1": "value1", "key2": {"key5": "value5"}}))
         d = OrderedDict({"key1": "value1", "key2": [{}]})
-        self.assertEqual(remove_empty_objects(d), OrderedDict({"key1": "value1"}))
+        self.assertDictEqual(remove_empty_objects(d), OrderedDict({"key1": "value1"}))

--- a/unit-tests/test_util_misc.py
+++ b/unit-tests/test_util_misc.py
@@ -6,11 +6,12 @@ __license__   = 'GPLv3, see LICENSE'
 
 import sys
 import time
+from collections import OrderedDict
 from unittest import TestCase
 
 sys.path.append('../util')
 
-from misc import human_readable_size, last_run_time_acceptable
+from misc import human_readable_size, last_run_time_acceptable, remove_empty_objects
 
 
 class UtilMiscTest(TestCase):
@@ -50,3 +51,13 @@ class UtilMiscTest(TestCase):
         self.assertEqual(output, "100.0 PiB")
         output = human_readable_size(3931462330709348188)
         self.assertEqual(output, "3.41 EiB")
+
+    def test_remove_empty_objects(self):
+        d = OrderedDict({"key1": None, "key2": "", "key3": {}, "key4": []})
+        self.assertEqual(remove_empty_objects(d), OrderedDict({}))
+        d = OrderedDict({"key1": "value1", "key2": {"key1": None, "key2": "", "key3": {}, "key4": []}})
+        self.assertEqual(remove_empty_objects(d), OrderedDict({"key1": "value1"}))
+        d = OrderedDict({"key1": "value1", "key2": {"key1": None, "key2": "", "key3": {}, "key4": [], "key5": "value5"}})
+        self.assertEqual(remove_empty_objects(d), OrderedDict({"key1": "value1", "key2": {"key5": "value5"}}))
+        d = OrderedDict({"key1": "value1", "key2": [{}]})
+        self.assertEqual(remove_empty_objects(d), OrderedDict({"key1": "value1"}))

--- a/util/misc.py
+++ b/util/misc.py
@@ -6,6 +6,7 @@ __license__   = 'GPLv3, see LICENSE'
 
 import math
 import time
+from collections import OrderedDict
 
 
 def last_run_time_acceptable(coll, found, last_run, config_backoff_time):
@@ -29,3 +30,23 @@ def human_readable_size(size_bytes):
     p = math.pow(1024, i)
     s = round(size_bytes / p, 2)
     return '{} {}'.format(s, size_name[i])
+
+
+def remove_empty_objects(d):
+    """Remove empty objects (None, '', {}, []) from OrderedDict."""
+    if isinstance(d, dict):
+        # Create OrderedDict to maintain order.
+        cleaned_dict = OrderedDict()
+        for k, v in d.items():
+            # Recursively remove empty objects.
+            cleaned_value = remove_empty_objects(v)
+            # Only add non-empty values.
+            if cleaned_value not in (None, '', {}, []):
+                cleaned_dict[k] = cleaned_value
+        return cleaned_dict
+    elif isinstance(d, list):
+        # Clean lists by filtering out empty objects.
+        return [remove_empty_objects(item) for item in d if remove_empty_objects(item) not in (None, '', {}, [])]
+    else:
+        # Return the value abecause it is not a dict or list.
+        return d


### PR DESCRIPTION
This PR should prevent three things:
- unrecoverable publication error when creating DataCite JSON with invalid affiliation metadata
- saving empty objects from metadata form (which could lead to errors in the publication flow)
- submitting for vault when affiliation metadata is not valid

Fixes https://github.com/UtrechtUniversity/yoda/issues/455