### PR TITLE
fix for adding users to existing group

### DIFF
--- a/groups.py
+++ b/groups.py
@@ -978,7 +978,7 @@ def group_create(ctx, group_name, category, subcategory, schema_id, expiration_d
         message = response[9]
         if status == '0':
             return api.Result.ok()
-        elif status == '-1089000' or status == '-809000':
+        elif status == '-1089000' or status == '-809000' or status == '-806000':
             return api.Error('group_exists', "Group {} not created, it already exists".format(group_name))
         else:
             return api.Error('policy_error', message)

--- a/uuGroup.r
+++ b/uuGroup.r
@@ -776,7 +776,7 @@ uuGroupAdd(*groupName, *category, *subcategory, *schema_id, *expiration_date, *d
 	*kv."co_identifier"		  = *co_identifier;
 
 	# Shoot first, ask questions later.
-        *status = str(errorcode(msiSudoGroupAdd(*groupName, "manager", uuClientFullName, "", *kv)));
+ 	*status = str(errorcode(msiSudoGroupAdd(*groupName, "manager", uuClientFullName, "", *kv)));
 
 	if (*status == '0') {
 		*message = "";


### PR DESCRIPTION
**Problem**

Users not added to group using CSV when folder is already created

**Solution**
There was an error when trying to create group, saying it already existed. (CAT_SQL_ERR: -806000). This did not allow user to be added to existing group. Now, we check for that.

When this error occurs, we print a log statement in irods log, and we then allow users to be added in existing group.
