### PR TITLE
Yda 5892 delete revision creation avu for data objects found in trash

### DIFF
--- a/revisions.py
+++ b/revisions.py
@@ -361,7 +361,7 @@ def rule_revision_batch(ctx, verbose, balance_id_min, balance_id_max, batch_size
 
         minimum_timestamp = int(time.time() - config.async_revision_delay_time)
 
-        # Remove revision creation AVUs from deleted data objects. 
+        # Remove revision creation AVUs from deleted data objects.
         # This makes it easier to monitor the number of data objects waiting for revision creation.
         remove_revision_creation_avu_from_deleted_data_objects(ctx)
 

--- a/revisions.py
+++ b/revisions.py
@@ -1066,8 +1066,6 @@ def remove_revision_creation_avu_from_deleted_data_objects(ctx, print_verbose):
 
     :param ctx:  Combined type of a callback and rei struct
     :param print_verbose: Whether to log verbose messages for troubleshooting (Boolean)
-
-    :raises Exception:       If removal of revision creation AVUs fails
     """
     revision_avu_name = constants.UUORGMETADATAPREFIX + "revision_scheduled"
 

--- a/revisions.py
+++ b/revisions.py
@@ -27,8 +27,7 @@ __all__ = ['api_revisions_restore',
            'rule_revision_batch',
            'rule_revisions_cleanup_collect',
            'rule_revisions_cleanup_process',
-           'rule_revisions_cleanup_scan',
-           "rule_remove_revision_creation_avu_from_deleted_data_objects"]
+           'rule_revisions_cleanup_scan']
 
 
 @api.make()
@@ -361,6 +360,10 @@ def rule_revision_batch(ctx, verbose, balance_id_min, balance_id_max, batch_size
         log.write(ctx, "Batch revision job started - balance id: {}-{}".format(balance_id_min, balance_id_max))
 
         minimum_timestamp = int(time.time() - config.async_revision_delay_time)
+
+        # Remove revision creation AVUs from deleted data objects. 
+        # This makes it easier to monitor the number of data objects waiting for revision creation.
+        remove_revision_creation_avu_from_deleted_data_objects(ctx)
 
         # Get list of up to batch size limit of data objects (in research space) scheduled for revision, taking into account
         # modification time.
@@ -1057,8 +1060,7 @@ def memory_limit_exceeded(rss_limit):
     return rss_limit and memory_rss_usage() > rss_limit
 
 
-@rule.make()
-def rule_remove_revision_creation_avu_from_deleted_data_objects(ctx):
+def remove_revision_creation_avu_from_deleted_data_objects(ctx):
     """
     Removes revision creation AVUs from deleted data objects [marked with 'org_revision_scheduled' metadata].
 

--- a/revisions.py
+++ b/revisions.py
@@ -1057,8 +1057,13 @@ def memory_limit_exceeded(rss_limit):
     return rss_limit and memory_rss_usage() > rss_limit
 
 
-@rule.make(inputs=[], outputs=[])
+@rule.make()
 def rule_remove_revision_creation_avu_from_deleted_data_objects(ctx):
+    """
+    Removes revision creation AVUs from deleted data objects [marked with 'org_revision_scheduled' metadata].
+
+    :raises Exception:       If removal of revision creation AVUs fails
+    """
     if user.user_type(ctx) != 'rodsadmin':
         raise Exception("This rule can only be executed by a rodsadmin user.")
 

--- a/revisions.py
+++ b/revisions.py
@@ -1062,6 +1062,8 @@ def rule_remove_revision_creation_avu_from_deleted_data_objects(ctx):
     """
     Removes revision creation AVUs from deleted data objects [marked with 'org_revision_scheduled' metadata].
 
+    :param ctx:  Combined type of a callback and rei struct
+
     :raises Exception:       If removal of revision creation AVUs fails
     """
     if user.user_type(ctx) != 'rodsadmin':

--- a/revisions.py
+++ b/revisions.py
@@ -1069,7 +1069,7 @@ def rule_remove_revision_creation_avu_from_deleted_data_objects(ctx):
         "COLL_NAME like '%{}/trash/home/%' AND META_DATA_ATTR_NAME = '{}'".format(user.zone(ctx), revision_avu_name),
         genquery.AS_LIST, ctx
     )
-    
+
     for coll_name, data_name in iter:
         path = coll_name + '/' + data_name
         try:


### PR DESCRIPTION
The job for revisions now removes revision creation AVUs from data objects in trash.
This makes it **easier to monitor** the number of data objects waiting for revision creation.

**Additions:**
A function that removes revision creation AVUs from data objects found in the trash.