### PR TITLE
Yda 5951 add transformation scopus isni

### DIFF
--- a/schema_transformations.py
+++ b/schema_transformations.py
@@ -7,6 +7,7 @@ __license__   = 'GPLv3, see LICENSE'
 import re
 
 import meta
+from schema_transformations_utils import correctify_isni, correctify_orcid, correctify_researcher_id, correctify_scopus
 from util import *
 
 
@@ -133,7 +134,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect ORCID format.
                     if not re.search("^(https://orcid.org/)[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$", person_identifier.get('Name_Identifier', None)):
                         corrected_orcid = correctify_orcid(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_orcid is None:
                             log.write(ctx, "Warning: could not correct ORCID %s during schema transformation. It needs to be fixed manually."
                                       % (person_identifier['Name_Identifier']))
@@ -144,7 +145,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect Scopus format.
                     if not re.search("^\d{1,11}$", person_identifier.get('Name_Identifier', None)):
                         corrected_scopus = correctify_scopus(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_scopus is None:
                             log.write(ctx, "Warning: could not correct Scopus %s during schema transformation. It needs to be fixed manually."
                                       % (person_identifier['Name_Identifier']))
@@ -155,7 +156,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect ISNI format.
                     if not re.search("^(https://isni.org/isni/)[0-9]{15}[0-9X]$", person_identifier.get('Name_Identifier', None)):
                         corrected_isni = correctify_isni(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_isni is None:
                             log.write(ctx, "Warning: could not correct ISNI %s during schema transformation. It needs to be fixed manually."
                                       % (person_identifier['Name_Identifier']))
@@ -165,7 +166,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect ResearcherID format.
                     if not re.search("^(https://www.researcherid.com/rid/)[A-Z]-[0-9]{4}-[0-9]{4}$", person_identifier.get('Name_Identifier', None)):
                         corrected_researcher_id = correctify_researcher_id(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_researcher_id != person_identifier['Name_Identifier']:
                             person_identifier['Name_Identifier'] = corrected_researcher_id
                 elif 'Name_Identifier_Scheme' not in person_identifier:
@@ -192,7 +193,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect ORCID format.
                     if not re.search("^(https://orcid.org/)[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$", person_identifier.get('Name_Identifier', None)):
                         corrected_orcid = correctify_orcid(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_orcid is None:
                             log.write(ctx, "Warning: could not correct ORCID %s during schema transformation. It needs to be fixed manually."
                                       % (person_identifier['Name_Identifier']))
@@ -203,7 +204,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect Scopus format.
                     if not re.search("^\d{1,11}$", person_identifier.get('Name_Identifier', None)):
                         corrected_scopus = correctify_scopus(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_scopus is None:
                             log.write(ctx, "Warning: could not correct Scopus %s during schema transformation. It needs to be fixed manually."
                                       % (person_identifier['Name_Identifier']))
@@ -214,7 +215,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect ISNI format.
                     if not re.search("^(https://isni.org/isni/)[0-9]{15}[0-9X]$", person_identifier.get('Name_Identifier', None)):
                         corrected_isni = correctify_isni(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_isni is None:
                             log.write(ctx, "Warning: could not correct ISNI %s during schema transformation. It needs to be fixed manually."
                                       % (person_identifier['Name_Identifier']))
@@ -224,7 +225,7 @@ def _default2_default3(ctx, m):
                     # Check for incorrect ResearcherID format.
                     if not re.search("^(https://www.researcherid.com/rid/)[A-Z]-[0-9]{4}-[0-9]{4}$", person_identifier.get('Name_Identifier', None)):
                         corrected_researcher_id = correctify_researcher_id(person_identifier['Name_Identifier'])
-                        # Only it an actual correction took place change the value and mark this data as 'changed'.
+                        # Only if an actual correction took place change the value and mark this data as 'changed'.
                         if corrected_researcher_id != person_identifier['Name_Identifier']:
                             person_identifier['Name_Identifier'] = corrected_researcher_id
                 elif 'Name_Identifier_Scheme' not in person_identifier:
@@ -748,66 +749,3 @@ def get(src_id, dst_id):
 
     x = transformations.get(src_id)
     return None if x is None else x.get(dst_id)
-
-
-def correctify_orcid(org_orcid):
-    """Correct illformatted ORCID."""
-    # Get rid of all spaces.
-    orcid = org_orcid.replace(' ', '')
-
-    # Upper-case X.
-    orcid = org_orcid.replace('x', 'X')
-
-    # The last part should hold a valid id like eg: 1234-1234-1234-123X.
-    # If not, it is impossible to correct it to the valid orcid format
-    orcs = orcid.split('/')
-    if not re.search("^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$", orcs[-1]):
-        # Return original value.
-        return org_orcid
-
-    return "https://orcid.org/{}".format(orcs[-1])
-
-
-def correctify_scopus(org_scopus):
-    """Correct illformatted Scopus."""
-    # Get rid of all spaces.
-    new_scopus = org_scopus.replace(' ', '')
-
-    if not re.search("^\d{1,11}$", new_scopus):
-        # Return original value.
-        return org_scopus
-
-    return new_scopus
-
-
-def correctify_isni(org_isni):
-    """Correct ill-formatted ISNI."""
-    # Remove all spaces.
-    new_isni = org_isni.replace(' ', '')
-
-    # Upper-case X.
-    new_isni = new_isni.replace('x', 'X')
-
-    # The last part should hold a valid id like eg: 123412341234123X.
-    # If not, it is impossible to correct it to the valid isni format
-    new_isni = new_isni.split('/')
-    if not re.search("^[0-9]{15}[0-9X]$", new_isni[-1]):
-        # Return original value.
-        return org_isni
-
-    return "https://isni.org/isni/{}".format(new_isni[-1])
-
-
-def correctify_researcher_id(org_researcher_id):
-    """Correct illformatted ResearcherID."""
-    # Get rid of all spaces.
-    researcher_id = org_researcher_id.replace(' ', '')
-
-    # The last part should hold a valid id like eg: A-1234-1234
-    # If not, it is impossible to correct it to the valid ResearcherID format
-    orcs = researcher_id.split('/')
-    if not re.search("^[A-Z]-[0-9]{4}-[0-9]{4}$", orcs[-1]):
-        # Return original value.
-        return org_researcher_id
-
-    return "https://www.researcherid.com/rid/{}".format(orcs[-1])

--- a/schema_transformations.py
+++ b/schema_transformations.py
@@ -795,7 +795,7 @@ def correctify_isni(org_isni):
         # Return original value.
         return org_isni
 
-    return "https://isni.org/isni/{}".format(new_isni)
+    return "https://isni.org/isni/{}".format(new_isni[-1])
 
 
 def correctify_researcher_id(org_researcher_id):

--- a/schema_transformations.py
+++ b/schema_transformations.py
@@ -6,8 +6,9 @@ __license__   = 'GPLv3, see LICENSE'
 
 import re
 
-import meta
 from schema_transformations_utils import correctify_isni, correctify_orcid, correctify_researcher_id, correctify_scopus
+
+import meta
 from util import *
 
 

--- a/schema_transformations_utils.py
+++ b/schema_transformations_utils.py
@@ -1,0 +1,61 @@
+import re
+
+
+def correctify_orcid(org_orcid):
+    """Correct illformatted ORCID."""
+    # Get rid of all spaces.
+    orcid = org_orcid.replace(' ', '')
+
+    # Upper-case X.
+    orcid = orcid.replace('x', 'X')
+
+    # The last part should hold a valid id like eg: 1234-1234-1234-123X.
+    # If not, it is impossible to correct it to the valid orcid format
+    orcs = orcid.split('/')
+    if not re.search("^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$", orcs[-1]):
+        return None
+
+    return "https://orcid.org/{}".format(orcs[-1])
+
+
+def correctify_scopus(org_scopus):
+    """Correct illformatted Scopus."""
+    # Get rid of all spaces.
+    new_scopus = org_scopus.replace(' ', '')
+
+    if not re.search("^\d{1,11}$", new_scopus):
+        return None
+
+    return new_scopus
+
+
+def correctify_isni(org_isni):
+    """Correct ill-formatted ISNI."""
+    # Remove all spaces.
+    new_isni = org_isni.replace(' ', '')
+
+    # Upper-case X.
+    new_isni = new_isni.replace('x', 'X')
+
+    # The last part should hold a valid id like eg: 123412341234123X.
+    # If not, it is impossible to correct it to the valid isni format
+    new_isni = new_isni.split('/')
+    if not re.search("^[0-9]{15}[0-9X]$", new_isni[-1]):
+        return None
+
+    return "https://isni.org/isni/{}".format(new_isni[-1])
+
+
+def correctify_researcher_id(org_researcher_id):
+    """Correct illformatted ResearcherID."""
+    # Get rid of all spaces.
+    researcher_id = org_researcher_id.replace(' ', '')
+
+    # The last part should hold a valid id like eg: A-1234-1234
+    # If not, it is impossible to correct it to the valid ResearcherID format
+    orcs = researcher_id.split('/')
+    if not re.search("^[A-Z]-[0-9]{4}-[0-9]{4}$", orcs[-1]):
+        # Return original value.
+        return org_researcher_id
+
+    return "https://www.researcherid.com/rid/{}".format(orcs[-1])

--- a/unit-tests/test_schema_transformations.py
+++ b/unit-tests/test_schema_transformations.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the correctify functions in schema_transformations"""
+
+__copyright__ = 'Copyright (c) 2024, Utrecht University'
+__license__   = 'GPLv3, see LICENSE'
+
+import sys
+from unittest import TestCase
+
+sys.path.append('..')
+
+from schema_transformations_utils import correctify_isni, correctify_orcid, correctify_researcher_id, correctify_scopus
+
+
+class CorrectifyIsniTest(TestCase):
+    def test_isni_correct_format(self):
+        """Test ISNI with correct format"""
+        isni = "https://isni.org/isni/1234123412341234"
+        self.assertEqual(correctify_isni(isni), isni)
+
+
+    def test_isni_correct_format_containing_x(self):
+        """Test ISNI with correct format"""
+        isni = "https://isni.org/isni/123412341234123x"
+        correct_isni = "https://isni.org/isni/123412341234123X"
+        self.assertEqual(correctify_isni(isni), correct_isni)
+
+
+    def test_isni_invalid_format(self):
+        """Test ISNI with invalid format (1 less number)"""
+        isni = "123412341234123"
+        self.assertIsNone(correctify_isni(isni))
+
+
+    def test_isni_malformed_format(self):
+        """Test ISNI with invalid format"""
+        isni = "foobar0123456789"
+        self.assertIsNone(correctify_isni(isni))
+
+
+    def test_isni_with_spaces(self):
+        """Test ISNI that contains spaces and should be corrected"""
+        isni = " https://isni.org/isni/123412341234123x    "
+        corrected_isni = "https://isni.org/isni/123412341234123X"
+        self.assertEqual(correctify_isni(isni), corrected_isni)
+
+
+class CorrectifyOrcidTest(TestCase):
+    def test_orcid_correct_format(self):
+        """Test ORCID with correct format"""
+        orcid = "https://orcid.org/1234-1234-1234-1234"
+        self.assertEqual(correctify_orcid(orcid), orcid)
+
+
+    def test_orcid_correct_format_containing_x(self):
+        """Test ORCID with correct format"""
+        orcid = "https://orcid.org/1234-1234-1234-123x"
+        correct_orcid = "https://orcid.org/1234-1234-1234-123X"
+        self.assertEqual(correctify_orcid(orcid), correct_orcid)
+
+        
+    def test_orcid_invalid_format(self):
+        """Test ORCID with invalid format (1 less number)"""
+        orcid = "1234-1234-1234-123"
+        self.assertIsNone(correctify_orcid(orcid))
+
+
+    def test_orcid_malformed_format(self):
+        """Test ORCID with invalid format"""
+        orcid = "1234-foo-bar-1234"
+        self.assertIsNone(correctify_orcid(orcid))
+
+
+    def test_orcid_with_spaces(self):
+        """Test ORCID that contains spaces and should be corrected"""
+        orcid = " https://orcid.org/1234-1234-1234-123x    "
+        corrected_orcid = "https://orcid.org/1234-1234-1234-123X"
+        self.assertEqual(correctify_orcid(orcid), corrected_orcid)
+
+
+class CorrectifyScopusTest(TestCase):
+    def test_correctify_format(self):
+        """Test SCOPUS with correct format"""
+        scopus = "12345678901"
+        self.assertEqual(correctify_scopus(scopus), scopus)
+
+    
+    def test_correctify_invalid_format(self):
+        """Test SCOPUS with invalid format"""
+        scopus = "123456789012"
+        self.assertIsNone(correctify_scopus(scopus))
+
+
+    def test_malformed_format(self):
+        """Test SCOPUS with invalid format"""
+        scopus = "foobar1234"
+        self.assertIsNone(correctify_scopus(scopus))
+
+
+    def test_orcid_with_spaces(self):
+        """Test SCOPUS that contains spaces and should be corrected"""
+        scopus = " 01234567890    "
+        corrected_scopus = "01234567890"
+        self.assertEqual(correctify_scopus(scopus), corrected_scopus)

--- a/unit-tests/test_schema_transformations.py
+++ b/unit-tests/test_schema_transformations.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 
 sys.path.append('..')
 
-from schema_transformations_utils import correctify_isni, correctify_orcid, correctify_researcher_id, correctify_scopus
+from schema_transformations_utils import correctify_isni, correctify_orcid, correctify_scopus
 
 
 class CorrectifyIsniTest(TestCase):
@@ -18,25 +18,21 @@ class CorrectifyIsniTest(TestCase):
         isni = "https://isni.org/isni/1234123412341234"
         self.assertEqual(correctify_isni(isni), isni)
 
-
     def test_isni_correct_format_containing_x(self):
         """Test ISNI with correct format"""
         isni = "https://isni.org/isni/123412341234123x"
         correct_isni = "https://isni.org/isni/123412341234123X"
         self.assertEqual(correctify_isni(isni), correct_isni)
 
-
     def test_isni_invalid_format(self):
         """Test ISNI with invalid format (1 less number)"""
         isni = "123412341234123"
         self.assertIsNone(correctify_isni(isni))
 
-
     def test_isni_malformed_format(self):
         """Test ISNI with invalid format"""
         isni = "foobar0123456789"
         self.assertIsNone(correctify_isni(isni))
-
 
     def test_isni_with_spaces(self):
         """Test ISNI that contains spaces and should be corrected"""
@@ -51,25 +47,21 @@ class CorrectifyOrcidTest(TestCase):
         orcid = "https://orcid.org/1234-1234-1234-1234"
         self.assertEqual(correctify_orcid(orcid), orcid)
 
-
     def test_orcid_correct_format_containing_x(self):
         """Test ORCID with correct format"""
         orcid = "https://orcid.org/1234-1234-1234-123x"
         correct_orcid = "https://orcid.org/1234-1234-1234-123X"
         self.assertEqual(correctify_orcid(orcid), correct_orcid)
 
-        
     def test_orcid_invalid_format(self):
         """Test ORCID with invalid format (1 less number)"""
         orcid = "1234-1234-1234-123"
         self.assertIsNone(correctify_orcid(orcid))
 
-
     def test_orcid_malformed_format(self):
         """Test ORCID with invalid format"""
         orcid = "1234-foo-bar-1234"
         self.assertIsNone(correctify_orcid(orcid))
-
 
     def test_orcid_with_spaces(self):
         """Test ORCID that contains spaces and should be corrected"""
@@ -84,18 +76,15 @@ class CorrectifyScopusTest(TestCase):
         scopus = "12345678901"
         self.assertEqual(correctify_scopus(scopus), scopus)
 
-    
     def test_correctify_invalid_format(self):
         """Test SCOPUS with invalid format"""
         scopus = "123456789012"
         self.assertIsNone(correctify_scopus(scopus))
 
-
     def test_malformed_format(self):
         """Test SCOPUS with invalid format"""
         scopus = "foobar1234"
         self.assertIsNone(correctify_scopus(scopus))
-
 
     def test_orcid_with_spaces(self):
         """Test SCOPUS that contains spaces and should be corrected"""

--- a/unit-tests/unit_tests.py
+++ b/unit-tests/unit_tests.py
@@ -5,6 +5,7 @@ __license__   = 'GPLv3, see LICENSE'
 
 from unittest import makeSuite, TestSuite
 
+from test_schema_transformations import CorrectifyIsniTest, CorrectifyOrcidTest, CorrectifyScopusTest
 from test_group_import import GroupImportTest
 from test_intake import IntakeTest
 from test_policies import PoliciesTest
@@ -16,6 +17,9 @@ from test_util_yoda_names import UtilYodaNamesTest
 
 def suite():
     test_suite = TestSuite()
+    test_suite.addTest(makeSuite(CorrectifyIsniTest))
+    test_suite.addTest(makeSuite(CorrectifyOrcidTest))
+    test_suite.addTest(makeSuite(CorrectifyScopusTest))
     test_suite.addTest(makeSuite(GroupImportTest))
     test_suite.addTest(makeSuite(IntakeTest))
     test_suite.addTest(makeSuite(PoliciesTest))

--- a/unit-tests/unit_tests.py
+++ b/unit-tests/unit_tests.py
@@ -5,11 +5,11 @@ __license__   = 'GPLv3, see LICENSE'
 
 from unittest import makeSuite, TestSuite
 
-from test_schema_transformations import CorrectifyIsniTest, CorrectifyOrcidTest, CorrectifyScopusTest
 from test_group_import import GroupImportTest
 from test_intake import IntakeTest
 from test_policies import PoliciesTest
 from test_revisions import RevisionTest
+from test_schema_transformations import CorrectifyIsniTest, CorrectifyOrcidTest, CorrectifyScopusTest
 from test_util_misc import UtilMiscTest
 from test_util_pathutil import UtilPathutilTest
 from test_util_yoda_names import UtilYodaNamesTest


### PR DESCRIPTION
The metadata schema transformation code from default-2 to default-3 currently handles ORCID-IDs and Researcher IDs, but not Scopus IDs and ISNI IDs. Because of this, metadata files with the default-2 schema containing Scopus or ISNI IDs can usually not be converted automatically to default-3. 

**Solution**
Add a transformation function that handles transformation of an ISNI and Scopus ID that consists of a series of digits (with optional spaces) to the format that is specified in the default-3 schema