### PR TITLE
CI: install any new portal dependencies if needed

### DIFF
--- a/.github/workflows/api-and-integration-tests.yml
+++ b/.github/workflows/api-and-integration-tests.yml
@@ -85,6 +85,7 @@ jobs:
         cd yoda/docker/compose
         docker exec portal.yoda sh -c 'set -x ; cd /var/www/yoda && git config remote.origin.fetch  "+refs/heads/*:refs/remotes/origin/*" && git pull'
         docker exec portal.yoda sh -c 'set -x ; cd /var/www/yoda && git checkout ${{ steps.extract_branch.outputs.branch }} || git checkout development'
+        docker exec portal.yoda sh -c 'set -x ; cd /var/www/yoda && . venv/bin/activate && venv/bin/pip3 install -r requirements.txt'
         docker exec portal.yoda sh -c 'set -x ; cd /var/www/yoda && git status'
         docker exec portal.yoda sh -c 'set -x ; touch /var/www/yoda/*.wsgi'
 


### PR DESCRIPTION
Install any new portal dependencies in CI. These may be needed for running the API tests if the dependencies of the portal have changed since the Docker image was last built.