### PR TITLE
YDA-6040: add portal info API tests

### DIFF
--- a/.github/workflows/api-and-integration-tests.yml
+++ b/.github/workflows/api-and-integration-tests.yml
@@ -123,6 +123,12 @@ jobs:
       run: |
         docker exec provider.yoda sh -c 'set -x ; cat /var/lib/irods/log/rodsLog*'
 
+
+    - name: Output web server logs
+      if: failure()
+      run: |
+        docker exec portal.yoda sh -c 'set -x ; for log in error.log portal_access.log ; do echo "${log}:" ; cat "/var/log/apache2/$log" ; echo; done'
+
 # Uncomment section below when needed for debugging.
 #
 #    - name: Setup tmate session for debugging

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,5 @@ import-order-style=smarkets
 strictness=short
 docstring_style=sphinx
 max-line-length=127
-exclude=__init__.py,tools,tests/env/
+exclude=__init__.py,tools,tests
 application-import-names=avu,conftest,util,api,config,constants,data_access_token,datacite,datarequest,data_object,epic,error,folder,groups,groups_import,json_datacite,json_landing_page,jsonutil,log,mail,meta,meta_form,msi,notifications,schema,schema_transformation,schema_transformations,settings,pathutil,provenance,policies_intake,policies_datamanager,policies_datapackage_status,policies_folder_status,policies_datarequest_status,publication,query,replication,revisions,revision_strategies,revision_utils,rule,user,vault,sram,arb_data_manager,cached_data_manager,resource,yoda_names,policies_utils

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ __license__   = 'GPLv3, see LICENSE'
 
 import json
 import re
+import sys
 
 import pytest
 import requests
@@ -194,7 +195,12 @@ def login(user, password):
     # Retrieve the login CSRF token.
     content = client.get(url, verify=False).content.decode()
     p = re.compile("tokenValue: '([a-zA-Z0-9._-]*)'")
-    csrf = p.findall(content)[0]
+    found_csrf_tokens = p.findall(content)
+    if len(found_csrf_tokens) == 0:
+        print(f"Error: could not find login CSRF token in response from server for login of user {user}. Response was:")
+        print(content)
+        sys.exit(1)
+    csrf = found_csrf_tokens[0]
 
     # Login as user.
     if verbose_test:
@@ -207,7 +213,12 @@ def login(user, password):
     # Retrieve the authenticated CSRF token.
     content = response.content.decode()
     p = re.compile("tokenValue: '([a-zA-Z0-9._-]*)'")
-    csrf = p.findall(content)[0]
+    found_csrf_tokens = p.findall(content)
+    if len(found_csrf_tokens) == 0:
+        print(f"Error: could not find authenticated CSRF token in response from server for login of user {user}. Response was:")
+        print(content)
+        sys.exit(1)
+    csrf = found_csrf_tokens[0]
 
     # Return CSRF and session cookies.
     if verbose_test:


### PR DESCRIPTION
On API test failures, print more information for troubleshooting purposes:
- CI: On failures, print web server error logs and portal access log for troubleshooting on portal level.
- API tests: if tests are unable to get a CSRF token, print the user that the error occurred with and the response from the web server for troubleshooting purposes.

(version for Yoda 1.10 and up)