### PR TITLE
YDA-6084: add sanity checks copy-to-vault

### DIFF
--- a/folder.py
+++ b/folder.py
@@ -17,6 +17,7 @@ import policies_folder_status
 import provenance
 import vault
 from util import *
+from vault_utils import get_sanity_checks_results_copy_to_vault_paths
 
 __all__ = ['rule_collection_group_name',
            'api_folder_get_locks',
@@ -569,6 +570,16 @@ def set_vault_target(ctx: rule.Context, coll: str, target: str) -> bool:
 def determine_and_set_vault_target(ctx: rule.Context, coll: str) -> str:
     """Determine and set target on coll"""
     found, target = get_existing_vault_target(ctx, coll)
+
+    # Overwrite vault target if it does not pass sanity checks. This should usually
+    # fix any wrong vault target. There's a second check in the copy_folder_to_vault
+    # function to prevent TOCTOU issues.
+    sanity_check_results = get_sanity_checks_results_copy_to_vault_paths(coll, target)
+    if len(sanity_check_results) > 0:
+        log.write(ctx, "folder_secure: overwriting previous vault target for " + coll
+                       + "(" + target + "), because it did not meet sanity checks: "
+                       + str(sanity_check_results))
+        found = False
 
     # Determine vault target if it does not exist.
     if not found:

--- a/unit-tests/test_vault.py
+++ b/unit-tests/test_vault.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 sys.path.append('..')
 
-from vault_utils import get_copy_folder_to_vault_irsync_command
+from vault_utils import get_copy_folder_to_vault_irsync_command, get_sanity_checks_results_copy_to_vault_paths
 
 
 class VaultTest(TestCase):
@@ -24,3 +24,35 @@ class VaultTest(TestCase):
     def test_get_copy_folder_to_vault_irsync_command_no_multithreading(self):
         output = get_copy_folder_to_vault_irsync_command("/zoneName/home/research-foo/abc", "/zoneName/home/vault-foo/abc", "vaultResc", False)
         self.assertEqual(output, ["irsync", "-rK", "-R", "vaultResc", "-N", "0", "i:/zoneName/home/research-foo/abc/", "i:/zoneName/home/vault-foo/abc/original"])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_ok(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo", "/tempZone/home/vault-foo")
+        self.assertEqual(output, [])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_relative_source(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("research-foo", "/tempZone/home/vault-foo")
+        self.assertEqual(output, ["Source path is not absolute."])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_relative_target(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo", "vault-foo")
+        self.assertEqual(output, ["Target path is not absolute."])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_dotdot_source(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo/..", "/tempZone/home/vault-foo")
+        self.assertEqual(output, ["Source path contains parent references (..)"])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_dotdot_target(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo", "/tempZone/home/../vault-foo")
+        self.assertEqual(output, ["Target path contains parent references (..)"])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_wrong_source_space(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/vault-foo", "/tempZone/home/vault-foo")
+        self.assertEqual(output, ["Source path not in research or deposit group."])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_wrong_target_space(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo", "/tempZone/home/deposit-foo")
+        self.assertEqual(output, ["Target path not in vault group."])
+
+    def test_get_sanity_check_results_copy_to_vault_paths_source_target_mismatch(self):
+        output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo", "/tempZone/home/vault-bar")
+        self.assertEqual(output, ["Source and target group are not in same compartment."])

--- a/vault.py
+++ b/vault.py
@@ -20,7 +20,7 @@ import meta_form
 import policies_datamanager
 import policies_datapackage_status
 from util import *
-from vault_utils import get_copy_folder_to_vault_irsync_command
+from vault_utils import get_copy_folder_to_vault_irsync_command, get_sanity_checks_results_copy_to_vault_paths
 
 __all__ = ['api_vault_submit',
            'api_vault_approve',
@@ -953,6 +953,12 @@ def copy_folder_to_vault(ctx: rule.Context, coll: str, target: str) -> bool:
 
     :returns: True for successful copy
     """
+    sanity_check_results = get_sanity_checks_results_copy_to_vault_paths(coll, target)
+    if len(sanity_check_results) > 0:
+        log.write(ctx, "Not copying folder to vault because of sanity check failures: "
+                  + str(sanity_check_results))
+        return False
+
     returncode = 0
     irsync_command = get_copy_folder_to_vault_irsync_command(coll,
                                                              target,

--- a/vault_utils.py
+++ b/vault_utils.py
@@ -5,6 +5,8 @@ __license__   = 'GPLv3, see LICENSE'
 
 from typing import List, Union
 
+from util import pathutil
+
 
 def get_copy_folder_to_vault_irsync_command(coll: str, target: str, vault_resource: Union[str, None], multi_threading: bool) -> List[str]:
     """Internal function to determine rsync command for copy-to-vault
@@ -28,3 +30,47 @@ def get_copy_folder_to_vault_irsync_command(coll: str, target: str, vault_resour
 
     irsync_command.extend(["i:{}/".format(coll), "i:{}/original".format(target)])
     return irsync_command
+
+
+def get_sanity_checks_results_copy_to_vault_paths(source: str, target: str) -> List[str]:
+    """Internal function to determine whether a source and destination path for
+       archiving data in the vault pass sanity checks.
+
+       :param source: source collection
+       :param target: target collection
+
+       :returns: list of sanity check fails (empty list means all tests passed)
+    """
+    failed: List[str] = []
+
+    if not source.startswith("/"):
+        failed.append("Source path is not absolute.")
+
+    if not target.startswith("/"):
+        failed.append("Target path is not absolute.")
+
+    if ".." in source.split("/"):
+        failed.append("Source path contains parent references (..)")
+
+    if ".." in target.split("/"):
+        failed.append("Target path contains parent references (..)")
+
+    if len(failed) > 0:
+        # The remaining tests assume absolute paths without parent references,
+        # so skip these tests if previous tests did not pass.
+        return failed
+
+    (source_space, source_zone, source_group, _) = pathutil.info(source)
+    (target_space, target_zone, target_group, _) = pathutil.info(target)
+
+    if source_space not in (pathutil.Space.DEPOSIT, pathutil.Space.RESEARCH):
+        failed.append("Source path not in research or deposit group.")
+
+    if target_space != pathutil.Space.VAULT:
+        failed.append("Target path not in vault group.")
+
+    if (source_zone != target_zone
+            or "-".join(source_group.split("-")[1:]) != "-".join(target_group.split("-")[1:])):
+        failed.append("Source and target group are not in same compartment.")
+
+    return failed


### PR DESCRIPTION
Add sanity checks for source and destination paths when copying data to the vault so that users can't make the vault module copy data in an unintended way by manipulating vault metadata. This also makes this part of the system more robust against unexpected inputs.