### PR TITLE
YDA-6059 fix datarequest api tests

### DIFF
--- a/.github/workflows/api-and-integration-tests.yml
+++ b/.github/workflows/api-and-integration-tests.yml
@@ -114,7 +114,7 @@ jobs:
         cd tests
         nohup bash -c 'while true ; do sleep 5 ;  ../yoda/docker/run-cronjob.sh copytovault >> ../copytovault.log 2>&1 ; ../yoda/docker/run-cronjob.sh publication >> ../publication.log 2>&1 ; done' &
         test -d mycache || mkdir -p mycache
-        python3 -m pytest --skip-ui --deposit -o cache_dir=mycache --environment environments/docker.json
+        python3 -m pytest --skip-ui --deposit --datarequest -o cache_dir=mycache --environment environments/docker.json
         cat ../copytovault.log
         cat ../publication.log
 

--- a/datarequest.py
+++ b/datarequest.py
@@ -875,12 +875,19 @@ def file_write_and_lock(ctx: rule.Context, coll_path: str, filename: str, data: 
     jsonutil.write(ctx, file_path, data)
 
     # Grant read permission to readers
+    current_user = user.full_name(ctx)  # Retrieve once
+
+    # Reorder readers: move current_user to the end if present
+    if current_user in readers:
+        readers = [reader for reader in readers if reader != current_user] + [current_user]
+
+    # Set read ACLs for each reader
     for reader in readers:
         msi.set_acl(ctx, "default", "read", reader, file_path)
 
-    # Revoke temporary write permission (unless read permissions were set on the invoking user)
-    if user.full_name(ctx) not in readers:
-        msi.set_acl(ctx, "default", "null", user.full_name(ctx), file_path)
+    # Revoke temporary write permission if current_user doesn't have read access
+    if current_user not in readers:
+        msi.set_acl(ctx, "default", "null", current_user, file_path)
     # If invoking user is request owner, set read permission for this user on the collection again,
     # else revoke individual user permissions on collection entirely (invoking users will still have
     # appropriate permissions through group membership, e.g. the project managers group)
@@ -962,12 +969,12 @@ def api_datarequest_submit(ctx: rule.Context, data: Dict, draft: bool, draft_req
         msi.set_acl(ctx, "default", "read", user.full_name(ctx), attachments_path)
         msi.set_acl(ctx, "default", "read", GROUP_PM, dta_path)
         msi.set_acl(ctx, "default", "read", GROUP_DM, dta_path)
-        msi.set_acl(ctx, "default", "read", user.full_name(ctx), dta_path)
         msi.set_acl(ctx, "default", "own", "rods", dta_path)
+        msi.set_acl(ctx, "default", "read", user.full_name(ctx), dta_path)
         msi.set_acl(ctx, "default", "read", GROUP_PM, sigdta_path)
         msi.set_acl(ctx, "default", "read", GROUP_DM, sigdta_path)
-        msi.set_acl(ctx, "default", "read", user.full_name(ctx), sigdta_path)
         msi.set_acl(ctx, "default", "own", "rods", sigdta_path)
+        msi.set_acl(ctx, "default", "read", user.full_name(ctx), sigdta_path)
 
         # Create provenance log
         provenance_path = "{}/{}".format(coll_path, PROVENANCE + JSON_EXT)
@@ -1904,7 +1911,7 @@ def api_datarequest_dta_post_upload_actions(ctx: rule.Context, request_id: str, 
 
     # Set status to dta_ready
     status_set(ctx, request_id, status.DTA_READY)
-    return api.OK()
+    return api.Result.ok()
 
 
 @api.make()
@@ -1971,7 +1978,7 @@ def api_datarequest_signed_dta_post_upload_actions(ctx: rule.Context, request_id
 
     # Set status to dta_signed
     status_set(ctx, request_id, status.DTA_SIGNED)
-    return api.OK()
+    return api.Result.ok()
 
 
 @api.make()


### PR DESCRIPTION
Root cause analysis: 
In irods, previously, the user can modify the ownership of the file without being the owner (the user may only have read-permission). but now, the user can only modify the ownership of the file, if they are the owner (or stronger rights like admin). For more discussion, see https://github.com/irods/irods/issues/6579 

What were done:
1. Failure in api_datarequest_submit and file_write_and_lock -> moved the current user to be the last who does permission or ownership modification
2. UPdated api.OK() call to api.Result.ok()

Note, in case you encountered the ReadTimeOut from HTTPConnectionPool, while running API tests. Try to update the timeout of HTTPConnectionPool, e.g, /yoda/yoda-ruleset/tests/venv_pytest/lib/python3.8/site-packages/urllib3/connectionpool.py in the function: _make_request()

![Screenshot from 2025-01-08 15-08-15](https://github.com/user-attachments/assets/6d886eb4-bc32-42ba-a6db-7ee9b1f6c93f)


 