### PR TITLE
YDA-6104: display role changes on group import

### DIFF
--- a/groups.py
+++ b/groups.py
@@ -565,7 +565,7 @@ def apply_data(ctx: rule.Context, data: Dict, allow_update: bool, delete_users: 
 
     for (category, subcategory, group_name, managers, members, viewers, schema_id, expiration_date) in data:
         new_group = False
-        users_added, users_removed = 0, 0
+        users_added, users_removed, roles_changed = 0, 0, 0
         message = ''
 
         log.write(ctx, 'CSV import - Adding and updating group: {}'.format(group_name))
@@ -613,6 +613,7 @@ def apply_data(ctx: rule.Context, data: Dict, allow_update: bool, delete_users: 
                 log.write(ctx, "CSV import - Notice: user {} already has role {} in group {}.".format(username, role, group_name))
             else:
                 response = group_user_update_role(ctx, username, group_name, role)
+                roles_changed += 1
 
                 if response:
                     log.write(ctx, "CSV import - Notice: changed role of user {} in group {} to {}".format(username, group_name, role))
@@ -668,9 +669,11 @@ def apply_data(ctx: rule.Context, data: Dict, allow_update: bool, delete_users: 
             message += ' Users added ({}).'.format(users_added)
         if users_removed > 0:
             message += ' Users removed ({}).'.format(users_removed)
+        if roles_changed > 0:
+            message += ' Roles changed ({}).'.format(roles_changed)
 
         # If no users added, no users removed and not new group created.
-        if not users_added and not users_removed and not new_group:
+        if not any((users_added, users_removed, roles_changed, new_group)):
             message += ' No changes made.'
 
     return {"status": "ok", "message": message}


### PR DESCRIPTION
When importing groups from a CSV file in the group manager, the portal did not show any role changes, which made it look like role changes were not processed.

This fix ensures that users can see any role changes that are made as a result of an import with the update flag enabled.