### PR TITLE
Yda-6102: refactor csv import in group manager module

### DIFF
--- a/groups_import.py
+++ b/groups_import.py
@@ -3,6 +3,8 @@
 __copyright__ = 'Copyright (c) 2018-2024, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
+import csv
+
 from typing import Dict, List, Set, Tuple
 
 from iteration_utilities import duplicates, unique_everseen
@@ -170,15 +172,15 @@ def parse_data(ctx: 'rule.Context', csv_header_and_data: str) -> Tuple:
     extracted_data = []
 
     csv_lines = csv_header_and_data.splitlines()
-    header = csv_lines[0]
-    import_lines = csv_lines[1:]
+    csv_reader = csv.reader(csv_lines)
+    header = next(csv_reader)
+    import_lines = list(csv_reader)
 
     # List of dicts each containing label / list of values pairs.
     lines = []
-    header_cols = header.split(',')
+    header_cols = header
     for import_line in import_lines:
-        data = import_line.split(',')
-        if len(data) != len(header_cols):
+        if len(import_line) != len(header_cols):
             return [], 'Amount of header columns differs from data columns.'
         # A kind of MultiDict
         # each key is a header column
@@ -195,8 +197,8 @@ def parse_data(ctx: 'rule.Context', csv_header_and_data: str) -> Tuple:
             if header_cols[x] not in line_dict:
                 line_dict[header_cols[x]] = []
 
-            if len(data[x]):
-                line_dict[header_cols[x]].append(data[x])
+            if len(import_line[x]):
+                line_dict[header_cols[x]].append(import_line[x])
 
         lines.append(line_dict)
 

--- a/groups_import.py
+++ b/groups_import.py
@@ -1,6 +1,6 @@
 """Functions related to importing group data."""
 
-__copyright__ = 'Copyright (c) 2018-2024, Utrecht University'
+__copyright__ = 'Copyright (c) 2018-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import csv

--- a/groups_import.py
+++ b/groups_import.py
@@ -172,12 +172,11 @@ def parse_data(ctx: 'rule.Context', csv_header_and_data: str) -> Tuple:
 
     csv_lines = csv_header_and_data.splitlines()
     csv_reader = csv.reader(csv_lines)
-    header = next(csv_reader)
+    header_cols = next(csv_reader)
     import_lines = list(csv_reader)
 
     # List of dicts each containing label / list of values pairs.
     lines = []
-    header_cols = header
     for import_line in import_lines:
         if len(import_line) != len(header_cols):
             return [], 'Amount of header columns differs from data columns.'

--- a/groups_import.py
+++ b/groups_import.py
@@ -4,7 +4,6 @@ __copyright__ = 'Copyright (c) 2018-2024, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import csv
-
 from typing import Dict, List, Set, Tuple
 
 from iteration_utilities import duplicates, unique_everseen

--- a/unit-tests/files/with-commas.csv
+++ b/unit-tests/files/with-commas.csv
@@ -1,0 +1,5 @@
+category,subcategory,groupname,manager,member,viewer
+test-automation,csv-test,"csv,test,group1",groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test
+test-automation,csv-test,"csv,test,group2",groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test
+test-automation,csv-test,"csv,test,group3",groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test
+test-automation,csv-test,"csv,test,group4",groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test

--- a/unit-tests/files/without-commas.csv
+++ b/unit-tests/files/without-commas.csv
@@ -1,0 +1,5 @@
+category,subcategory,groupname,manager,member,viewer
+test-automation,csv-test,csv-test-group1,groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test
+test-automation,csv-test,csv-test-group2,groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test
+test-automation,csv-test,csv-test-group3,groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test
+test-automation,csv-test,csv-test-group4,groupmanager@yoda.test,researcher@yoda.test,viewer@yoda.test

--- a/unit-tests/test_group_import.py
+++ b/unit-tests/test_group_import.py
@@ -221,3 +221,15 @@ class GroupImportTest(TestCase):
         no_duplicate_data, no_duplicate_err = self.parse_csv_file("files/without-duplicates2.csv")
         self.assertNotEqual(no_duplicate_data, [])
         self.assertEqual(no_duplicate_err, '')
+
+
+    def test_parse_csv_file_commas(self):
+        # CSV file with commas
+        commas_data, commas_err = self.parse_csv_file("files/with-commas.csv")
+        self.assertEqual(commas_data, [])
+        self.assertIn("Data error", commas_err)
+
+         # CSV file without duplicates
+        no_commas_data, no_commas_err = self.parse_csv_file("files/without-commas.csv")
+        self.assertNotEqual(no_commas_data, [])
+        self.assertEqual(no_commas_err, '') 

--- a/unit-tests/test_group_import.py
+++ b/unit-tests/test_group_import.py
@@ -1,7 +1,6 @@
-"""Unit tests for the groups functionality
-"""
+"""Unit tests for the groups functionality."""
 
-__copyright__ = 'Copyright (c) 2019-2024, Utrecht University'
+__copyright__ = 'Copyright (c) 2019-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import io

--- a/unit-tests/test_group_import.py
+++ b/unit-tests/test_group_import.py
@@ -222,14 +222,13 @@ class GroupImportTest(TestCase):
         self.assertNotEqual(no_duplicate_data, [])
         self.assertEqual(no_duplicate_err, '')
 
-
     def test_parse_csv_file_commas(self):
         # CSV file with commas
         commas_data, commas_err = self.parse_csv_file("files/with-commas.csv")
         self.assertEqual(commas_data, [])
         self.assertIn("Data error", commas_err)
 
-         # CSV file without duplicates
+        # CSV file without duplicates
         no_commas_data, no_commas_err = self.parse_csv_file("files/without-commas.csv")
         self.assertNotEqual(no_commas_data, [])
-        self.assertEqual(no_commas_err, '') 
+        self.assertEqual(no_commas_err, '')


### PR DESCRIPTION
This is a refactor of  csv parsing in Group Manager.

- Replaced custom CSV parsing logic in Group Manager with Python's built-in csv library.
- Resolves the issue where commas in column values caused parsing errors by leveraging the library's robust handling of CSV format.