### PR TITLE
YDA-6085: incomplete metadata reported as invalid

### DIFF
--- a/policies_datapackage_status.py
+++ b/policies_datapackage_status.py
@@ -40,7 +40,7 @@ def can_transition_datapackage_status(ctx: rule.Context,
             return policy.fail('Metadata missing, unable to submit this data package for publication.')
 
         if not meta.is_json_metadata_valid(ctx, meta_path):
-            return policy.fail('Metadata is not valid, please open the metadata form for more information')
+            return policy.fail('Metadata is either incomplete or invalid, please open the metadata form for more information')
 
     return policy.succeed()
 

--- a/policies_datapackage_status.py
+++ b/policies_datapackage_status.py
@@ -40,7 +40,7 @@ def can_transition_datapackage_status(ctx: rule.Context,
             return policy.fail('Metadata missing, unable to submit this data package for publication.')
 
         if not meta.is_json_metadata_valid(ctx, meta_path):
-            return policy.fail('Metadata is either incomplete or invalid, please open the metadata form for more information')
+            return policy.fail('Metadata is incomplete or invalid, please open the metadata form for more information')
 
     return policy.succeed()
 

--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -70,7 +70,7 @@ def can_transition_folder_status(ctx: rule.Context,
             return policy.fail('Metadata missing, unable to submit this folder')
 
         if not meta.is_json_metadata_valid(ctx, meta_path):
-            return policy.fail('Metadata is not valid, please open the metadata form for more information')
+            return policy.fail('Metadata is either incomplete or invalid, please open the metadata form for more information')
 
     elif status_to in [constants.research_package_state.ACCEPTED,
                        constants.research_package_state.REJECTED]:

--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -70,7 +70,7 @@ def can_transition_folder_status(ctx: rule.Context,
             return policy.fail('Metadata missing, unable to submit this folder')
 
         if not meta.is_json_metadata_valid(ctx, meta_path):
-            return policy.fail('Metadata is either incomplete or invalid, please open the metadata form for more information')
+            return policy.fail('Metadata is incomplete or invalid, please open the metadata form for more information')
 
     elif status_to in [constants.research_package_state.ACCEPTED,
                        constants.research_package_state.REJECTED]:


### PR DESCRIPTION
This fix changes the message shown when attempting to submit a data package (or folder) with incomplete or invalid metadata.