### PR TITLE
YDA-6243: Fix el9 ca_file permission issue when running arb-update-resources.py

### DIFF
--- a/tools/arb-update-resources.py
+++ b/tools/arb-update-resources.py
@@ -193,9 +193,9 @@ def main():
     args = parse_args()
     env = get_irods_environment()
 
-    for ca_file_option in ["/etc/pki/tls/certs/chain.pem",
-                           "/etc/ssl/certs/chain.crt",
-                           "/etc/ssl/certs/localhost.crt"]:
+    for ca_file_option in ["/etc/irods/localhost_and_chain.crt",
+                           "/etc/ssl/certs/ca-certificates.crt",
+                           "/etc/pki/tls/certs/ca-bundle.crt"]:
         if os.path.isfile(ca_file_option):
             ca_file = ca_file_option
             break


### PR DESCRIPTION
This is a fix for el9 ca_file permission issue when running arb-update-resources.py