### PR TITLE
Yda 6068 add csv output to troubleshoot tool

### DIFF
--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -208,7 +208,7 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, wri
     # Set encoding to utf-8 for the response text (otherwise will not match local_data)
     # response.text is then returned as unicode
     response.encoding = 'utf-8'
-    local_data_uni = local_data.decode("utf-8")
+    local_data_uni = local_data #.decode("utf-8") # TODO: This causes error
 
     if local_data_uni == response.text:
         return True

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -331,19 +331,21 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     :returns: A dictionary of dictionaries providing the results of the job.
     """
 
+    # Only write_stdout when in human mode and api_call is not enabled
     write_stdout = not api_call and (mode == 'human')
     # Check permissions - rodsadmin only
     if user.user_type(ctx) != 'rodsadmin':
         log.write(ctx, "User is not rodsadmin", write_stdout)
         return {}
 
+    # Collect data packages
     data_packages = collect_troubleshoot_data_packages(ctx, requested_package, write_stdout)
     if not data_packages:
         return {}
     schema_cache = {}
     results = {}
 
-    # Troubleshooting steps
+    # Troubleshooting packages
     for data_package in data_packages:
         result = {}
 
@@ -383,7 +385,8 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     converted_results = {}
     for pkg, res in results.items():
         converted_results[pkg] = {
-            key: 'Pass' if value else 'Fail' if isinstance(value, bool) else value
+            # All values are expected to be booleans from earlier checks
+            key: 'Pass' if value else 'Fail'
             for key, value in res.items()
         }
 

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -414,13 +414,10 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
 @rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])
 def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite, mode):
 
-    results = batch_troubleshoot_published_data_packages(
-        ctx, requested_package,
-        log_file == "True",
-        offline == "True",
-        False,  # api_call = False
-        no_datacite == "False",
-        mode
-    )
+    offline = offline == "True"
+    log_file = log_file == "True"
+    check_datacite = no_datacite == "False"
+
+    results = batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, False, check_datacite, mode)
 
     return json.dumps(results)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -337,7 +337,8 @@ def collect_troubleshoot_data_packages(ctx, requested_package, write_stdout):
     return data_packages
 
 
-def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, api_call, check_datacite):
+
+def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, api_call, check_datacite, mode):
     """
     Troubleshoots published data packages.
 
@@ -350,6 +351,8 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
+    log.write(ctx, f"Starting troubleshooting in {mode} mode", not api_call)
+    
     write_stdout = not api_call
     # Check permissions - rodsadmin only
     if user.user_type(ctx) != 'rodsadmin':
@@ -426,14 +429,18 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
     #return None #TODO: return JSON data 
     return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False)
 
-@rule.make(inputs=[0, 1, 2, 3], outputs=[4])
-def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite):
+@rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])
+def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite, mode):
+    """Entry point for rule execution with format mode"""
+    log.write(ctx, f"Received output mode: {mode}", True)
+    
     results = batch_troubleshoot_published_data_packages(
-        ctx, requested_package, 
+        ctx, requested_package,
         log_file == "True",
         offline == "True",
         False,  # api_call
-        no_datacite == "False"
+        no_datacite == "False",
+        mode
     )
     
     return json.dumps(results)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -398,7 +398,15 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
                 json.dump(result, writer)
                 writer.writelines('\n')
 
-    return results
+    # Convert booleans to Pass/Fail strings
+    converted_results = {}
+    for pkg, res in results.items():
+        converted_results[pkg] = {
+            key: 'Pass' if value else 'Fail' if isinstance(value, bool) else value
+            for key, value in res.items()
+        }
+
+    return converted_results
 
 
 @api.make()
@@ -428,12 +436,4 @@ def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_
         no_datacite == "False"
     )
     
-    # Convert booleans to Pass/Fail strings
-    converted_results = {}
-    for pkg, res in results.items():
-        converted_results[pkg] = {
-            key: 'Pass' if value else 'Fail' if isinstance(value, bool) else value
-            for key, value in res.items()
-        }
-    
-    return json.dumps(converted_results)
+    return json.dumps(results)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -343,22 +343,38 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     schema_cache = {}
     results = {}
 
-    # Troubleshooting
+    # Troubleshooting steps
     for data_package in data_packages:
         result = {}
+        
+        log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout) 
+        
         if not api_call:
             schema_check_dict = vault_metadata_matches_schema(ctx, data_package, schema_cache, "troubleshoot-publications", write_stdout)
             result['Schema Check'] = schema_check_dict['match_schema'] if schema_check_dict else False
-
-        # Modified log calls to use write_stdout
         result['Missing AVUs Check'], result['Unexpected AVUs Check'] = check_print_data_package_system_avus(ctx, data_package, write_stdout)
-
         result['Landing Page Check'] = check_landingpage(ctx, data_package, offline, api_call, write_stdout)
+
+        # Only check Version and Base DOI if check_datacite enabled
+        base_doi_check = None 
+        if check_datacite:
+            version_doi_check, base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
+            result['Version DOI Check'] = version_doi_check
+        else:
+            result['Version DOI Check'] = False
+
+        # Handle base DOI only if present
+        if base_doi_check is not None:
+            result['Base DOI Check'] = base_doi_check
+        else:
+            result['Base DOI Check'] = False
+
         publication_config = get_publication_config(ctx)
         result['Combi JSON Check'] = check_combi_json(ctx, data_package, publication_config, offline, write_stdout)
 
         results[data_package] = result
 
+        # Save to log file if log_file == True
         if log_file:
             log_loc = "/var/lib/irods/log/troubleshoot_publications.log"
             with open(log_loc, "a") as writer:
@@ -398,13 +414,12 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
 
 @rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])
 def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite, mode):
-    """Entry point for rule execution with format mode"""
 
     results = batch_troubleshoot_published_data_packages(
         ctx, requested_package,
         log_file == "True",
         offline == "True",
-        False,  # api_call
+        False,  # TODO: IMprove it? this is the api_call
         no_datacite == "False",
         mode
     )

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -326,7 +326,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     :param offline:           A boolean representing whether to perform all checks without connecting to external servers.
     :param api_call:          Boolean of whether this is run by a script or api test.
     :param check_datacite:    Boolean representing whether to do the datacite checks
-    :param mode:              A string representing output format, either 'human' or 'csv'
+    :param mode:              A string representing output format, either 'human' (default) or 'csv'
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
@@ -400,7 +400,6 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
     :param requested_package: A string representing a specific data package path or all packages with failed publications.
     :param log_file:          A boolean representing to write results in log.
     :param offline:           A boolean representing whether to perform all checks without connecting to external servers.
-    :param mode:              A string representing output format, either 'human' or 'csv'
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -347,7 +347,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     for data_package in data_packages:
         result = {}
 
-        log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout) 
+        log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout)
         if not api_call:
             schema_check_dict = vault_metadata_matches_schema(ctx, data_package, schema_cache, "troubleshoot-publications", write_stdout)
             result['Schema Check'] = schema_check_dict['match_schema'] if schema_check_dict else False

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -205,12 +205,8 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, wri
         log.write(ctx, "compare_local_remote_landingpage: Error {} when connecting to <{}>.".format(response.status_code, url), write_stdout)
         return False
 
-    # Set encoding to utf-8 for the response text (otherwise will not match local_data)
-    # response.text is then returned as unicode
     response.encoding = 'utf-8'
-    local_data_uni = local_data.decode("utf-8")
-
-    if local_data_uni == response.text:
+    if local_data == response.text:
         return True
 
     log.write(ctx, "compare_local_remote_landingpage: File contents at irods path <{}> and remote landing page <{}> do not match.".format(file_path, url), write_stdout)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -174,6 +174,7 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, wri
     :param url:          URL of file on remote
     :param offline:      Whether to skip requests.get call
     :param api_call:     Boolean representing whether was called by api and not a script
+    :param write_stdout: Boolean representing whether to write to stdout or rodsLog
 
     :returns:         True if the file contents match, False otherwise
     """
@@ -224,6 +225,7 @@ def check_landingpage(ctx, data_package, offline, api_call, write_stdout):
     :param data_package:       String representing the data package collection path.
     :param offline:            Whether to skip any checks that require external server access
     :param api_call:           Boolean of whether this is for an api call version of the troubleshooting script
+    :param write_stdout:       Boolean representing whether to write to stdout or rodsLog
 
     :returns:                  A tuple containing boolean results of checking
     """
@@ -314,7 +316,6 @@ def collect_troubleshoot_data_packages(ctx, requested_package, write_stdout):
     return data_packages
 
 
-
 def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, api_call, check_datacite, mode):
     """
     Troubleshoots published data packages.
@@ -325,10 +326,11 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     :param offline:           A boolean representing whether to perform all checks without connecting to external servers.
     :param api_call:          Boolean of whether this is run by a script or api test.
     :param check_datacite:    Boolean representing whether to do the datacite checks
+    :param mode               A string representing output format, either 'human' or 'csv'
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
-    
+
     write_stdout = not api_call and (mode == 'human')
     # Check permissions - rodsadmin only
     if user.user_type(ctx) != 'rodsadmin':
@@ -350,15 +352,12 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
         # Modified log calls to use write_stdout
         result['Missing AVUs Check'], result['Unexpected AVUs Check'] = check_print_data_package_system_avus(ctx, data_package, write_stdout)
-        
+
         result['Landing Page Check'] = check_landingpage(ctx, data_package, offline, api_call, write_stdout)
         publication_config = get_publication_config(ctx)
         result['Combi JSON Check'] = check_combi_json(ctx, data_package, publication_config, offline, write_stdout)
 
         results[data_package] = result
-
-        #if not api_call:
-        #    print_troubleshoot_result(ctx, data_package, result, check_datacite)
 
         if log_file:
             log_loc = "/var/lib/irods/log/troubleshoot_publications.log"
@@ -396,10 +395,11 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
     """
     return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False)
 
+
 @rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])
 def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite, mode):
     """Entry point for rule execution with format mode"""
-    
+
     results = batch_troubleshoot_published_data_packages(
         ctx, requested_package,
         log_file == "True",
@@ -408,5 +408,5 @@ def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_
         no_datacite == "False",
         mode
     )
-    
+
     return json.dumps(results)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -414,30 +414,20 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
+    log.write(ctx, "I am at api_batch_troubleshoot_published_data_packages")
+    #return None #TODO: return JSON data 
     return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False)
 
-
-@rule.make(inputs=[0, 1, 2, 3], outputs=[])
+@rule.make(inputs=[0, 1, 2, 3], outputs=[4])
 def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite):
-    """
-    Troubleshoots published data packages.
-
-    Prints results of the following checks:
-        1. Metadata schema compliance.
-        2. Presence and correctness of expected AVUs.
-        3. Registration with Data Cite.
-        4. File integrity of landing page and combi JSON files.
-
-    Operates on either a single specified package or all published packages, depending on the input.
-
-    :param ctx:               Context that combines a callback and rei struct.
-    :param requested_package: A string representing a specific data package path or all packages with failed publications.
-    :param log_file:          A string boolean representing to write results in log.
-    :param offline:           A string boolean representing whether to perform all checks without connecting to external servers.
-    :param no_datacite:       A string boolean representing whether to skip the datacite checks
-    """
-    offline = offline == "True"
-    log_file = log_file == "True"
-    check_datacite = no_datacite == "False"
-
-    batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, False, check_datacite)
+    # Existing logic to get results
+    results = batch_troubleshoot_published_data_packages(
+        ctx, requested_package, 
+        log_file == "True",
+        offline == "True",
+        False,  # api_call
+        no_datacite == "False"
+    )
+    
+    # Return results as JSON string
+    return json.dumps(results)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -10,6 +10,7 @@ __all__ = [
 
 import json
 from datetime import datetime
+from typing import Dict, List, Tuple, Union
 
 import genquery
 import requests
@@ -21,7 +22,7 @@ from publication import get_publication_config
 from util import *
 
 
-def find_full_package_path(ctx, package_name, write_stdout):
+def find_full_package_path(ctx: rule.Context, package_name: str, write_stdout: bool) -> Union[str, None]:
     """
     Find the full path of a data package based on its short name.
 
@@ -45,10 +46,11 @@ def find_full_package_path(ctx, package_name, write_stdout):
             return row[0]
     except Exception as e:
         log.write(ctx, "find_full_package_path: An error occurred while executing the query: {}".format(e), write_stdout)
-        return None
+
+    return None
 
 
-def find_data_packages(ctx, write_stdout):
+def find_data_packages(ctx: rule.Context, write_stdout: bool) -> List[str]:
     """
     Find all data packages in Retry, Unrecoverable and Unknown status by matching its AVU.
 
@@ -76,7 +78,7 @@ def find_data_packages(ctx, write_stdout):
         return []
 
 
-def check_print_data_package_system_avus(ctx, data_package, write_stdout):
+def check_print_data_package_system_avus(ctx: rule.Context, data_package: str, write_stdout: bool) -> Tuple[bool, bool]:
     """
     Checks whether a data package has the expected system AVUs that start with constants.UUORGMETADATAPREFIX (i.e, 'org_').
     This function compares the AVUs of the provided data package against a set of ground truth AVUs derived from
@@ -101,7 +103,7 @@ def check_print_data_package_system_avus(ctx, data_package, write_stdout):
     return (results["no_missing_avus"], results["no_unexpected_avus"])
 
 
-def check_one_datacite_doi_reg(ctx, data_package, doi_name, write_stdout):
+def check_one_datacite_doi_reg(ctx: rule.Context, data_package: str, doi_name: str, write_stdout: bool) -> bool:
     try:
         doi = get_val_for_attr_with_pub_prefix(ctx, data_package, doi_name)
     except ValueError as e:
@@ -112,7 +114,7 @@ def check_one_datacite_doi_reg(ctx, data_package, doi_name, write_stdout):
     return status_code == 200
 
 
-def check_datacite_doi_registration(ctx, data_package, write_stdout):
+def check_datacite_doi_registration(ctx: rule.Context, data_package: str, write_stdout: bool) -> Tuple[bool, Union[bool, None]]:
     """
     Check the registration status of both versionDOI and baseDOI with the DataCite API,
     ensuring that both DOIs return a 200 status code, which indicates successful registration.
@@ -138,7 +140,7 @@ def check_datacite_doi_registration(ctx, data_package, write_stdout):
     return (version_doi_check, None)
 
 
-def get_val_for_attr_with_pub_prefix(ctx, data_package, attribute_suffix):
+def get_val_for_attr_with_pub_prefix(ctx: rule.Context, data_package: str, attribute_suffix: str) -> str:
     """
     Retrieves the value given the suffix of the attribute from a data package.
 
@@ -152,7 +154,7 @@ def get_val_for_attr_with_pub_prefix(ctx, data_package, attribute_suffix):
     return avu.get_attr_val_of_coll(ctx, data_package, attr)
 
 
-def get_landingpage_paths(ctx, data_package, write_stdout):
+def get_landingpage_paths(ctx: rule.Context, data_package: str, write_stdout: bool) -> Tuple[str, str]:
     """Given a data package get what the path and remote url should be"""
     file_path = ''
     try:
@@ -165,7 +167,7 @@ def get_landingpage_paths(ctx, data_package, write_stdout):
         return '', ''
 
 
-def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, write_stdout):
+def compare_local_remote_landingpage(ctx: rule.Context, file_path: str, url: str, offline: bool, api_call: bool, write_stdout: bool) -> bool:
     """
     Compares file contents between a file in irods and its remote version to verify their integrity.
 
@@ -213,7 +215,7 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, wri
     return False
 
 
-def check_landingpage(ctx, data_package, offline, api_call, write_stdout):
+def check_landingpage(ctx: rule.Context, data_package: str, offline: bool, api_call: bool, write_stdout: bool) -> bool:
     """
     Checks the integrity of landing page by comparing the contents
 
@@ -234,7 +236,7 @@ def check_landingpage(ctx, data_package, offline, api_call, write_stdout):
     )
 
 
-def check_combi_json(ctx, data_package, publication_config, offline, write_stdout):
+def check_combi_json(ctx: rule.Context, data_package: str, publication_config: Dict[str, str], offline: bool, write_stdout: bool) -> bool:
     """
     Checks the integrity of combi JSON by checking URL and existence of file.
 
@@ -288,7 +290,7 @@ def check_combi_json(ctx, data_package, publication_config, offline, write_stdou
     return True
 
 
-def collect_troubleshoot_data_packages(ctx, requested_package, write_stdout):
+def collect_troubleshoot_data_packages(ctx: rule.Context, requested_package: str, write_stdout: bool) -> Union[List[str], None]:
     data_packages = []
 
     if requested_package == 'None':
@@ -312,7 +314,7 @@ def collect_troubleshoot_data_packages(ctx, requested_package, write_stdout):
     return data_packages
 
 
-def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, api_call, check_datacite, mode="human"):
+def batch_troubleshoot_published_data_packages(ctx: rule.Context, requested_package: str, log_file: bool, offline: bool, api_call: bool, check_datacite: bool, mode: str = "human") -> Dict[str, Dict[str, str]]:
     """
     Troubleshoots published data packages.
 
@@ -390,7 +392,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
 
 @api.make()
-def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline):
+def api_batch_troubleshoot_published_data_packages(ctx: rule.Context, requested_package: str, log_file: bool, offline: bool) -> Dict[str, Dict[str, str]]:
     """
     Wrapper for the batch script for troubleshooting published data packages.
     Runs a subset of the tests since "technicaladmin" is usually more restricted than "rods".
@@ -406,7 +408,7 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
 
 
 @rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])
-def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite, mode):
+def rule_batch_troubleshoot_published_data_packages(ctx: rule.Context, requested_package: str, log_file: bool, offline: bool, no_datacite: bool, mode: str) -> str:
 
     offline = offline == "True"
     log_file = log_file == "True"

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -165,7 +165,7 @@ def get_landingpage_paths(ctx, data_package, write_stdout):
         return '', ''
 
 
-def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call):
+def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, write_stdout):
     """
     Compares file contents between a file in irods and its remote version to verify their integrity.
 
@@ -177,7 +177,6 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call):
 
     :returns:         True if the file contents match, False otherwise
     """
-    write_stdout = not api_call
     # Local/irods file
     if api_call:
         # If called by technicaladmin, only check that the file exists since we don't have access to the contents
@@ -217,7 +216,7 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call):
     return False
 
 
-def check_landingpage(ctx, data_package, offline, api_call):
+def check_landingpage(ctx, data_package, offline, api_call, write_stdout):
     """
     Checks the integrity of landing page by comparing the contents
 
@@ -232,7 +231,9 @@ def check_landingpage(ctx, data_package, offline, api_call):
     if len(irods_file_path) == 0 or len(landing_page_url) == 0:
         return False
 
-    return compare_local_remote_landingpage(ctx, irods_file_path, landing_page_url, offline, api_call)
+    return compare_local_remote_landingpage(
+        ctx, irods_file_path, landing_page_url, offline, api_call, write_stdout
+    )
 
 
 def check_combi_json(ctx, data_package, publication_config, offline, write_stdout):
@@ -327,9 +328,8 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
-    log.write(ctx, f"Starting troubleshooting in {mode} mode", not api_call)
     
-    write_stdout = not api_call
+    write_stdout = not api_call and (mode == 'human')
     # Check permissions - rodsadmin only
     if user.user_type(ctx) != 'rodsadmin':
         log.write(ctx, "User is not rodsadmin", write_stdout)
@@ -343,22 +343,15 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
     # Troubleshooting
     for data_package in data_packages:
-        log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout)
         result = {}
-        # Cannot check the metadata as technicaladmin
         if not api_call:
             schema_check_dict = vault_metadata_matches_schema(ctx, data_package, schema_cache, "troubleshoot-publications", write_stdout)
             result['Schema Check'] = schema_check_dict['match_schema'] if schema_check_dict else False
 
+        # Modified log calls to use write_stdout
         result['Missing AVUs Check'], result['Unexpected AVUs Check'] = check_print_data_package_system_avus(ctx, data_package, write_stdout)
-
-        # Only check datacite if enabled
-        if check_datacite:
-            result['Version DOI Check'], base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
-            if base_doi_check is not None:
-                result['Base DOI Check'] = base_doi_check
-
-        result['Landing Page Check'] = check_landingpage(ctx, data_package, offline, api_call)
+        
+        result['Landing Page Check'] = check_landingpage(ctx, data_package, offline, api_call, write_stdout)
         publication_config = get_publication_config(ctx)
         result['Combi JSON Check'] = check_combi_json(ctx, data_package, publication_config, offline, write_stdout)
 
@@ -401,14 +394,11 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
-    log.write(ctx, "I am at api_batch_troubleshoot_published_data_packages")
-    #return None #TODO: return JSON data 
     return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False)
 
 @rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])
 def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite, mode):
     """Entry point for rule execution with format mode"""
-    log.write(ctx, f"Received output mode: {mode}", True)
     
     results = batch_troubleshoot_published_data_packages(
         ctx, requested_package,

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -358,7 +358,7 @@ def batch_troubleshoot_published_data_packages(ctx: rule.Context, requested_pack
         if check_datacite:
             result['Version DOI Check'], base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
             if base_doi_check is not None:
-                result['baseDOI_check'] = base_doi_check
+                result['Base DOI Check'] = base_doi_check
         else:
             result['Version DOI Check'] = True
             result['Base DOI Check'] = True

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -347,6 +347,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     for data_package in data_packages:
         result = {}
 
+        # Cannot check the metadata as technicaladmin
         if not api_call:
             schema_check_dict = vault_metadata_matches_schema(ctx, data_package, schema_cache, "troubleshoot-publications", write_stdout)
             result['Schema Check'] = schema_check_dict['match_schema'] if schema_check_dict else False

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -208,7 +208,7 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, wri
     # Set encoding to utf-8 for the response text (otherwise will not match local_data)
     # response.text is then returned as unicode
     response.encoding = 'utf-8'
-    local_data_uni = local_data #.decode("utf-8") # TODO: This causes error
+    local_data_uni = local_data.decode("utf-8")
 
     if local_data_uni == response.text:
         return True
@@ -355,18 +355,13 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
         result['Landing Page Check'] = check_landingpage(ctx, data_package, offline, api_call, write_stdout)
 
         # Only check Version and Base DOI if check_datacite enabled
-        base_doi_check = None
         if check_datacite:
             version_doi_check, base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
             result['Version DOI Check'] = version_doi_check
-        else:
-            result['Version DOI Check'] = False
-
-        # Handle base DOI only if present
-        if base_doi_check is not None:
             result['Base DOI Check'] = base_doi_check
         else:
-            result['Base DOI Check'] = False
+            result['Version DOI Check'] = True
+            result['Base DOI Check'] = True
 
         publication_config = get_publication_config(ctx)
         result['Combi JSON Check'] = check_combi_json(ctx, data_package, publication_config, offline, write_stdout)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -298,17 +298,17 @@ def print_troubleshoot_result(ctx, data_package, result, datacite_check):
         log.write(ctx, "Package passed all tests.", True)
     else:
         log.write(ctx, "Package FAILED one or more tests:", True)
-        log.write(ctx, "Schema matches: {}".format(result['schema_check']), True)
-        log.write(ctx, "All expected AVUs exist: {}".format(result['no_missing_AVUs_check']), True)
-        log.write(ctx, "No unexpected AVUs: {}".format(result['no_unexpected_AVUs_check']), True)
+        log.write(ctx, "Schema matches: {}".format('Pass' if result['schema_check'] else 'Fail'), True)
+        log.write(ctx, "All expected AVUs exist: {}".format('Pass' if result['no_missing_AVUs_check'] else 'Fail'), True)
+        log.write(ctx, "No unexpected AVUs: {}".format('Pass' if result['no_unexpected_AVUs_check'] else 'Fail'), True)
 
         if datacite_check:
-            log.write(ctx, "Version DOI matches: {}".format(result['versionDOI_check']), True)
+            log.write(ctx, "Version DOI matches: {}".format('Pass' if result['versionDOI_check'] else 'Fail'), True)
             if 'baseDOI_check' in result:
-                log.write(ctx, "Base DOI matches: {}".format(result['baseDOI_check']), True)
+                log.write(ctx, "Base DOI matches: {}".format('Pass' if result['baseDOI_check'] else 'Fail'), True)
 
-        log.write(ctx, "Landing page matches: {}".format(result['landingPage_check']), True)
-        log.write(ctx, "Combined JSON matches: {}".format(result['combiJson_check']), True)
+        log.write(ctx, "Landing page matches: {}".format('Pass' if result['landingPage_check'] else 'Fail'), True)
+        log.write(ctx, "Combined JSON matches: {}".format('Pass' if result['combiJson_check'] else 'Fail'), True)
 
     log.write(ctx, "", True)
 
@@ -420,7 +420,6 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
 
 @rule.make(inputs=[0, 1, 2, 3], outputs=[4])
 def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, no_datacite):
-    # Existing logic to get results
     results = batch_troubleshoot_published_data_packages(
         ctx, requested_package, 
         log_file == "True",
@@ -429,5 +428,12 @@ def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_
         no_datacite == "False"
     )
     
-    # Return results as JSON string
-    return json.dumps(results)
+    # Convert booleans to Pass/Fail strings
+    converted_results = {}
+    for pkg, res in results.items():
+        converted_results[pkg] = {
+            key: 'Pass' if value else 'Fail' if isinstance(value, bool) else value
+            for key, value in res.items()
+        }
+    
+    return json.dumps(converted_results)

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -289,30 +289,6 @@ def check_combi_json(ctx, data_package, publication_config, offline, write_stdou
     return True
 
 
-def print_troubleshoot_result(ctx, data_package, result, datacite_check):
-    """Print the result of troubleshooting one package in human-friendly format"""
-    pass_all_tests = all(result.values())
-
-    log.write(ctx, "Results for: {}".format(data_package), True)
-    if pass_all_tests:
-        log.write(ctx, "Package passed all tests.", True)
-    else:
-        log.write(ctx, "Package FAILED one or more tests:", True)
-        log.write(ctx, "Schema matches: {}".format('Pass' if result['schema_check'] else 'Fail'), True)
-        log.write(ctx, "All expected AVUs exist: {}".format('Pass' if result['no_missing_AVUs_check'] else 'Fail'), True)
-        log.write(ctx, "No unexpected AVUs: {}".format('Pass' if result['no_unexpected_AVUs_check'] else 'Fail'), True)
-
-        if datacite_check:
-            log.write(ctx, "Version DOI matches: {}".format('Pass' if result['versionDOI_check'] else 'Fail'), True)
-            if 'baseDOI_check' in result:
-                log.write(ctx, "Base DOI matches: {}".format('Pass' if result['baseDOI_check'] else 'Fail'), True)
-
-        log.write(ctx, "Landing page matches: {}".format('Pass' if result['landingPage_check'] else 'Fail'), True)
-        log.write(ctx, "Combined JSON matches: {}".format('Pass' if result['combiJson_check'] else 'Fail'), True)
-
-    log.write(ctx, "", True)
-
-
 def collect_troubleshoot_data_packages(ctx, requested_package, write_stdout):
     data_packages = []
 
@@ -372,24 +348,24 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
         # Cannot check the metadata as technicaladmin
         if not api_call:
             schema_check_dict = vault_metadata_matches_schema(ctx, data_package, schema_cache, "troubleshoot-publications", write_stdout)
-            result['schema_check'] = schema_check_dict['match_schema'] if schema_check_dict else False
+            result['Schema Check'] = schema_check_dict['match_schema'] if schema_check_dict else False
 
-        result['no_missing_AVUs_check'], result['no_unexpected_AVUs_check'] = check_print_data_package_system_avus(ctx, data_package, write_stdout)
+        result['Missing AVUs Check'], result['Unexpected AVUs Check'] = check_print_data_package_system_avus(ctx, data_package, write_stdout)
 
         # Only check datacite if enabled
         if check_datacite:
-            result['versionDOI_check'], base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
+            result['Version DOI Check'], base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
             if base_doi_check is not None:
-                result['baseDOI_check'] = base_doi_check
+                result['Base DOI Check'] = base_doi_check
 
-        result['landingPage_check'] = check_landingpage(ctx, data_package, offline, api_call)
+        result['Landing Page Check'] = check_landingpage(ctx, data_package, offline, api_call)
         publication_config = get_publication_config(ctx)
-        result['combiJson_check'] = check_combi_json(ctx, data_package, publication_config, offline, write_stdout)
+        result['Combi JSON Check'] = check_combi_json(ctx, data_package, publication_config, offline, write_stdout)
 
         results[data_package] = result
 
-        if not api_call:
-            print_troubleshoot_result(ctx, data_package, result, check_datacite)
+        #if not api_call:
+        #    print_troubleshoot_result(ctx, data_package, result, check_datacite)
 
         if log_file:
             log_loc = "/var/lib/irods/log/troubleshoot_publications.log"

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -208,7 +208,7 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, wri
     # Set encoding to utf-8 for the response text (otherwise will not match local_data)
     # response.text is then returned as unicode
     response.encoding = 'utf-8'
-    local_data_uni = local_data#.decode("utf-8")
+    local_data_uni = local_data.decode("utf-8")
 
     if local_data_uni == response.text:
         return True
@@ -316,7 +316,7 @@ def collect_troubleshoot_data_packages(ctx, requested_package, write_stdout):
     return data_packages
 
 
-def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, api_call, check_datacite, mode):
+def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, api_call, check_datacite, mode="human"):
     """
     Troubleshoots published data packages.
 
@@ -391,7 +391,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
 
 @api.make()
-def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, mode):
+def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline):
     """
     Wrapper for the batch script for troubleshooting published data packages.
     Runs a subset of the tests since "technicaladmin" is usually more restricted than "rods".
@@ -400,10 +400,11 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
     :param requested_package: A string representing a specific data package path or all packages with failed publications.
     :param log_file:          A boolean representing to write results in log.
     :param offline:           A boolean representing whether to perform all checks without connecting to external servers.
+    :param mode:              A string representing output format, either 'human' or 'csv'
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
-    return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False, mode)
+    return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False)
 
 
 @rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -326,7 +326,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     :param offline:           A boolean representing whether to perform all checks without connecting to external servers.
     :param api_call:          Boolean of whether this is run by a script or api test.
     :param check_datacite:    Boolean representing whether to do the datacite checks
-    :param mode               A string representing output format, either 'human' or 'csv'
+    :param mode:              A string representing output format, either 'human' or 'csv'
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
@@ -346,9 +346,8 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     # Troubleshooting steps
     for data_package in data_packages:
         result = {}
-        
+
         log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout) 
-        
         if not api_call:
             schema_check_dict = vault_metadata_matches_schema(ctx, data_package, schema_cache, "troubleshoot-publications", write_stdout)
             result['Schema Check'] = schema_check_dict['match_schema'] if schema_check_dict else False
@@ -356,7 +355,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
         result['Landing Page Check'] = check_landingpage(ctx, data_package, offline, api_call, write_stdout)
 
         # Only check Version and Base DOI if check_datacite enabled
-        base_doi_check = None 
+        base_doi_check = None
         if check_datacite:
             version_doi_check, base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
             result['Version DOI Check'] = version_doi_check
@@ -419,7 +418,7 @@ def rule_batch_troubleshoot_published_data_packages(ctx, requested_package, log_
         ctx, requested_package,
         log_file == "True",
         offline == "True",
-        False,  # TODO: IMprove it? this is the api_call
+        False,  # api_call = False
         no_datacite == "False",
         mode
     )

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -208,7 +208,7 @@ def compare_local_remote_landingpage(ctx, file_path, url, offline, api_call, wri
     # Set encoding to utf-8 for the response text (otherwise will not match local_data)
     # response.text is then returned as unicode
     response.encoding = 'utf-8'
-    local_data_uni = local_data.decode("utf-8")
+    local_data_uni = local_data#.decode("utf-8")
 
     if local_data_uni == response.text:
         return True
@@ -356,9 +356,9 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
         # Only check Version and Base DOI if check_datacite enabled
         if check_datacite:
-            version_doi_check, base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
-            result['Version DOI Check'] = version_doi_check
-            result['Base DOI Check'] = base_doi_check
+            result['Version DOI Check'], base_doi_check = check_datacite_doi_registration(ctx, data_package, write_stdout)
+            if base_doi_check is not None:
+                result['baseDOI_check'] = base_doi_check
         else:
             result['Version DOI Check'] = True
             result['Base DOI Check'] = True
@@ -391,7 +391,7 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
 
 
 @api.make()
-def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline):
+def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, mode):
     """
     Wrapper for the batch script for troubleshooting published data packages.
     Runs a subset of the tests since "technicaladmin" is usually more restricted than "rods".
@@ -403,7 +403,7 @@ def api_batch_troubleshoot_published_data_packages(ctx, requested_package, log_f
 
     :returns: A dictionary of dictionaries providing the results of the job.
     """
-    return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False)
+    return batch_troubleshoot_published_data_packages(ctx, requested_package, log_file, offline, True, False, mode)
 
 
 @rule.make(inputs=[0, 1, 2, 3, 4], outputs=[5])

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -347,7 +347,6 @@ def batch_troubleshoot_published_data_packages(ctx, requested_package, log_file,
     for data_package in data_packages:
         result = {}
 
-        log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout)
         if not api_call:
             schema_check_dict = vault_metadata_matches_schema(ctx, data_package, schema_cache, "troubleshoot-publications", write_stdout)
             result['Schema Check'] = schema_check_dict['match_schema'] if schema_check_dict else False

--- a/tests/step_defs/api/common_vault.py
+++ b/tests/step_defs/api/common_vault.py
@@ -179,7 +179,7 @@ def api_vault_batch_troubleshoot(user, vault, data_package):
     http_status, result = api_request(
         user,
         "batch_troubleshoot_published_data_packages",
-        {"requested_package": data_package, "log_file": True, "offline": True, "mode": "human"}
+        {"requested_package": data_package, "log_file": True, "offline": True}
     )
     assert http_status == 200
     data = result['data']

--- a/tests/step_defs/api/common_vault.py
+++ b/tests/step_defs/api/common_vault.py
@@ -179,14 +179,14 @@ def api_vault_batch_troubleshoot(user, vault, data_package):
     http_status, result = api_request(
         user,
         "batch_troubleshoot_published_data_packages",
-        {"requested_package": data_package, "log_file": True, "offline": True}
+        {"requested_package": data_package, "log_file": True, "offline": True, "mode": "human"}
     )
     assert http_status == 200
     data = result['data']
     assert len(data) == 1
     # Confirm that all checks passed for this data package
     for checks in data.values():
-        assert all(checks.values())
+        assert all(value == "Pass" for value in checks.values())
 
 
 @then('preservable formats lists are returned')

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -10,6 +10,9 @@ python3 troubleshoot-published-data.py -p research-initial[1725262507]
 
 To put results into a log file and complete the checks offline:
 python3 troubleshoot-published-data.py -l -o
+
+To output result in csv format:
+python3 troubleshoot-published-data.py -m csv
 """
 import argparse
 import subprocess

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -21,13 +21,13 @@ def parse_args():
         description=__doc__,
         formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-l", "--log-file", action='store_true',
-                        help="Write results to log file")
+                        help="If log file parameter is true then write to log at: /var/lib/irods/log/troubleshoot_publications.log")
     parser.add_argument("-o", "--offline", action='store_true',
-                        help="Perform checks without external connections")
+                        help="If actions should be performed without connecting to external servers (needed for the Yoda team's development setup).")
     parser.add_argument("-n", "--no-datacite", action='store_true',
-                        help="Skip DataCite DOI checks")
-    parser.add_argument("-p", "--package", type=str,
-                        help="Specific package to check")
+                        help="If datacite check should be skipped (needed for the Yoda team's development environment in some cases).")
+    parser.add_argument("-p", "--package", type=str, required=False,
+                        help="Troubleshoot a specific data package by name (default: troubleshoot all packages)")
     parser.add_argument("-m", "--mode", choices=['human', 'csv'], default='human',
                         help="Output format: human-readable (default) or CSV")
     return parser.parse_args()

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -21,25 +21,28 @@ def parse_args():
         description=__doc__,
         formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-l", "--log-file", action='store_true',
-                        help="If log file parameter is true then write to log at: /var/lib/irods/log/troubleshoot_publications.log")
+                        help="Write results to log file")
     parser.add_argument("-o", "--offline", action='store_true',
-                        help="If actions should be performed without connecting to external servers (needed for the Yoda team's development setup).")
+                        help="Perform checks without external connections")
     parser.add_argument("-n", "--no-datacite", action='store_true',
-                        help="If datacite check should be skipped (needed for the Yoda team's development environment in some cases).")
-    parser.add_argument("-p", "--package", type=str, required=False,
-                        help="Troubleshoot a specific data package by name (default: troubleshoot all packages)")
+                        help="Skip DataCite DOI checks")
+    parser.add_argument("-p", "--package", type=str,
+                        help="Specific package to check")
+    parser.add_argument("-m", "--mode", choices=['human', 'csv'], default='human',
+                        help="Output format: human-readable (default) or CSV")
     return parser.parse_args()
-
 
 def main():
     args = parse_args()
     rule_name = "/etc/irods/yoda-ruleset/tools/troubleshoot_data.r"
-    data_package = f"*data_package={args.package}"
-    log_loc = f"*log_loc={args.log_file if args.log_file else ''}"
-    offline = f"*offline={args.offline}"
-    no_datacite = f"*no_datacite={args.no_datacite}"
-    subprocess.call(['irule', '-r', 'irods_rule_engine_plugin-python-instance', '-F',
-                    rule_name, data_package, log_loc, offline, no_datacite])
+    params = [
+        f"*data_package={args.package or 'None'}",
+        f"*log_loc={'true' if args.log_file else 'false'}",
+        f"*offline={'true' if args.offline else 'false'}",
+        f"*no_datacite={'true' if args.no_datacite else 'false'}",
+        f"*mode={args.mode}"
+    ]
+    subprocess.call(['irule', '-r', 'irods_rule_engine_plugin-python-instance', '-F', rule_name] + params)
 
 
 if __name__ == '__main__':

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -28,7 +28,7 @@ def parse_args():
                         help="If datacite check should be skipped (needed for the Yoda team's development environment in some cases).")
     parser.add_argument("-p", "--package", type=str, required=False,
                         help="Troubleshoot a specific data package by name (default: troubleshoot all packages)")
-    parser.add_argument("-m", "--mode", choices=['human', 'csv', 'CSV'], default='human',
+    parser.add_argument("-m", "--mode", choices=['human', 'csv'], default='human',
                         help="Output format: human-readable (default) or CSV")
     return parser.parse_args()
 
@@ -40,7 +40,7 @@ def main():
         f"*log_loc={'true' if args.log_file else 'false'}",
         f"*offline={'true' if args.offline else 'false'}",
         f"*no_datacite={'true' if args.no_datacite else 'false'}",
-        f"*mode={args.mode.lower()}"  
+        f"*mode={args.mode}"  
     ]
     subprocess.call(['irule', '-r', 'irods_rule_engine_plugin-python-instance', '-F', rule_name] + params)
 

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -35,15 +35,15 @@ def parse_args():
 def main():
     args = parse_args()
     rule_name = "/etc/irods/yoda-ruleset/tools/troubleshoot_data.r"
-    params = [
-        f"*data_package={args.package or 'None'}",
-        f"*log_loc={'true' if args.log_file else 'false'}",
-        f"*offline={'true' if args.offline else 'false'}",
-        f"*no_datacite={'true' if args.no_datacite else 'false'}",
-        f"*mode={args.mode}"  
-    ]
-    subprocess.call(['irule', '-r', 'irods_rule_engine_plugin-python-instance', '-F', rule_name] + params)
 
+    data_package = f"*data_package={args.package}"
+    log_loc = f"*log_loc={args.log_file if args.log_file else ''}"
+    offline = f"*offline={args.offline}"
+    no_datacite = f"*no_datacite={args.no_datacite}"
+    mode = f"*mode={args.mode}"
+    
+    subprocess.call(['irule', '-r', 'irods_rule_engine_plugin-python-instance', '-F',
+                    rule_name, data_package, log_loc, offline, no_datacite, mode])
 
 if __name__ == '__main__':
     main()

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -40,7 +40,7 @@ def main():
         f"*log_loc={'true' if args.log_file else 'false'}",
         f"*offline={'true' if args.offline else 'false'}",
         f"*no_datacite={'true' if args.no_datacite else 'false'}",
-        f"*mode={args.mode}"
+        f"*mode={args.mode.lower()}"  
     ]
     subprocess.call(['irule', '-r', 'irods_rule_engine_plugin-python-instance', '-F', rule_name] + params)
 

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -38,7 +38,6 @@ def parse_args():
 def main():
     args = parse_args()
     rule_name = "/etc/irods/yoda-ruleset/tools/troubleshoot_data.r"
-
     data_package = f"*data_package={args.package}"
     log_loc = f"*log_loc={args.log_file if args.log_file else ''}"
     offline = f"*offline={args.offline}"

--- a/tools/troubleshoot-published-data.py
+++ b/tools/troubleshoot-published-data.py
@@ -28,7 +28,7 @@ def parse_args():
                         help="If datacite check should be skipped (needed for the Yoda team's development environment in some cases).")
     parser.add_argument("-p", "--package", type=str, required=False,
                         help="Troubleshoot a specific data package by name (default: troubleshoot all packages)")
-    parser.add_argument("-m", "--mode", choices=['human', 'csv'], default='human',
+    parser.add_argument("-m", "--mode", choices=['human', 'csv', 'CSV'], default='human',
                         help="Output format: human-readable (default) or CSV")
     return parser.parse_args()
 

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -25,7 +25,8 @@ def generate_csv(results):
         res = results[package]
         row = [package]
         for field in HEADERS[1:]:
-            # Get value or N/A if missing
+            # Get value or N/A if headers missing in the result
+            # A check result of N/A means the check is not needed for this package
             value = res.get(field, 'N/A')
             row.append(str(value) if value not in ('Pass', 'Fail') else value)
         writer.writerow(row)

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -16,7 +16,7 @@ HEADERS = [
 ]
 
 def generate_csv(results):
-    """Generate CSV output from results"""
+    """Generate CSV output from troubleshooting results"""
     output = io.StringIO()
     writer = csv.writer(output)
     writer.writerow(HEADERS)
@@ -28,10 +28,9 @@ def generate_csv(results):
     return output.getvalue().encode('utf-8')
 
 def generate_human_output(results):
-    """Generate human-readable output from results"""
+    """Generate human-readable output from troubleshooting results"""
     output = []
     for package in sorted(results.keys()):
-        # log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout) #TODO: how to add this to output?
         res = results[package]
         section = [
             f"Results for: {package}",
@@ -50,25 +49,25 @@ def generate_human_output(results):
     return '\n\n'.join(output).encode('utf-8')
 
 def main(rule_args, callback, rei):
-    try:
-        params = {
-            'data_package': global_vars["*data_package"].strip('"'),
-            'mode': global_vars["*mode"].strip('"').lower()
-        }
-        
-        if params['mode'] not in ('human', 'csv'):
-            raise ValueError("Invalid mode. Use 'human' or 'csv'")
+    # Prepare input parameters
+    params = {
+        'data_package': global_vars["*data_package"].strip('"'),
+        'mode': global_vars["*mode"].strip('"').lower()
+    }
+    
+    # Validate output format 
+    if params['mode'] not in ('human', 'csv'):
+        raise ValueError("Invalid mode. Use 'human' or 'csv'")
 
-        ret_val = callback.rule_batch_troubleshoot_published_data_packages(
-            params['data_package'], "", "", "", params['mode'], ""
-        )
-        results = json.loads(ret_val["arguments"][5])
+    # Run Python troubleshooting rule
+    ret_val = callback.rule_batch_troubleshoot_published_data_packages(
+        params['data_package'], "", "", "", params['mode'], ""
+    )
+    results = json.loads(ret_val["arguments"][5])
 
-        output = generate_csv(results) if params['mode'] == 'csv' else generate_human_output(results)
-        callback.writeLine("stdout", output)
-
-    except Exception as e:
-        callback.writeLine("stdout", f"Error: {str(e)}".encode('utf-8'))
-
+    # Generate output
+    output = generate_csv(results) if params['mode'] == 'csv' else generate_human_output(results)
+    callback.writeLine("stdout", output)
+    
 INPUT *data_package="", *log_loc="", *offline="", *no_datacite="", *mode=""
 OUTPUT ruleExecOut

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -4,62 +4,70 @@ import csv
 import io
 import json
 
-def main(rule_args, callback, rei):
-    # Read input parameters
-    data_package = global_vars["*data_package"].strip('"')
-    log_loc = global_vars["*log_loc"].strip('"')
-    offline = global_vars["*offline"].strip('"')
-    no_datacite = global_vars["*no_datacite"].strip('"')
-    mode = global_vars["*mode"].strip('"')
-    #callback.writeLine("stdout", mode.encode('utf-8'))
+HEADERS = [
+    "Package", 
+    "Schema Check",
+    "Missing AVUs Check",
+    "Unexpected AVUs Check",
+    "Version DOI Check",
+    "Base DOI Check",
+    "Landing Page Check",
+    "Combi JSON Check"
+]
 
-    # Pass all parameters to Python rule
-    ret_val = callback.rule_batch_troubleshoot_published_data_packages(
-        data_package,
-        log_loc,
-        offline,
-        no_datacite,
-        mode,
-        "" 
-    )
-    
-    results = json.loads(ret_val["arguments"][5])
-
-    # Create text buffer
+def generate_csv(results):
+    """Generate CSV output from results"""
     output = io.StringIO()
     writer = csv.writer(output)
+    writer.writerow(HEADERS)
+    
+    for package in sorted(results.keys()):
+        row = [package] + [results[package].get(field, 'N/A') for field in HEADERS[1:]]
+        writer.writerow(row)
+    
+    return output.getvalue().encode('utf-8')
 
-    # Write CSV header
-    writer.writerow([
-        "Package", 
-        "Schema Check",
-        "Missing AVUs Check",
-        "Unexpected AVUs Check",
-        "Version DOI Check",
-        "Base DOI Check",
-        "Landing Page Check",
-        "Combi JSON Check"
-    ])
-    callback.writeLine("stdout", output.getvalue().strip().encode('utf-8'))
-    output.seek(0)
-    output.truncate()
-
-    # Write CSV rows
+def generate_human_output(results):
+    """Generate human-readable output from results"""
+    output = []
     for package in sorted(results.keys()):
         res = results[package]
-        writer.writerow([
-            package,
-            res.get('schema_check', 'N/A'),
-            res.get('no_missing_AVUs_check', 'N/A'),
-            res.get('no_unexpected_AVUs_check', 'N/A'),
-            res.get('versionDOI_check', 'N/A'),
-            res.get('baseDOI_check', 'N/A'),
-            res.get('landingPage_check', 'N/A'),
-            res.get('combiJson_check', 'N/A')
-        ])
-        callback.writeLine("stdout", output.getvalue().strip().encode('utf-8'))
-        output.seek(0)
-        output.truncate()
+        section = [
+            f"Results for: {package}",
+            "Package passed all tests." if all(
+                res.get(field, 'N/A') == 'Pass' 
+                for field in HEADERS[1:]  # Skip Package
+            ) else "Package FAILED one or more tests:"
+        ]
+        
+        if "FAILED" in section[-1]:
+            for field in HEADERS[1:]:  # Skip Package
+                section.append(f"{field}: {res.get(field, 'N/A')}")
+        
+        output.append('\n'.join(section))
+    
+    return '\n\n'.join(output).encode('utf-8')
+
+def main(rule_args, callback, rei):
+    try:
+        params = {
+            'data_package': global_vars["*data_package"].strip('"'),
+            'mode': global_vars["*mode"].strip('"').lower()
+        }
+        
+        if params['mode'] not in ('human', 'csv'):
+            raise ValueError("Invalid mode. Use 'human' or 'csv'")
+
+        ret_val = callback.rule_batch_troubleshoot_published_data_packages(
+            params['data_package'], "", "", "", params['mode'], ""
+        )
+        results = json.loads(ret_val["arguments"][5])
+
+        output = generate_csv(results) if params['mode'] == 'csv' else generate_human_output(results)
+        callback.writeLine("stdout", output)
+
+    except Exception as e:
+        callback.writeLine("stdout", f"Error: {str(e)}".encode('utf-8'))
 
 INPUT *data_package="", *log_loc="", *offline="", *no_datacite="", *mode=""
 OUTPUT ruleExecOut

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -40,8 +40,8 @@ def generate_human_output(results):
         present_fields = [field for field in HEADERS[1:] if field in res]
         
         status_line = (
-            "Package passed all tests." 
-            if all(res[field] == 'Pass' for field in present_fields) 
+            "Package passed all tests."
+            if all(res[field] == 'Pass' for field in present_fields)
             else "Package FAILED one or more tests:"
         )
         
@@ -67,10 +67,6 @@ def main(rule_args, callback, rei):
         'mode': global_vars["*mode"].strip('"').lower()
     }
     
-    # Validate mode before proceeding
-    if params['mode'] not in ('human', 'csv'):
-        raise ValueError("Invalid mode. Use 'human' or 'csv'")
-
     # Execute troubleshooting with all parameters
     ret_val = callback.rule_batch_troubleshoot_published_data_packages(
         params['data_package'],

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -55,10 +55,6 @@ def main(rule_args, callback, rei):
         'mode': global_vars["*mode"].strip('"').lower()
     }
     
-    # Validate output format 
-    if params['mode'] not in ('human', 'csv'):
-        raise ValueError("Invalid mode. Use 'human' or 'csv'")
-
     # Run Python troubleshooting rule
     ret_val = callback.rule_batch_troubleshoot_published_data_packages(
         params['data_package'], "", "", "", params['mode'], ""
@@ -68,6 +64,6 @@ def main(rule_args, callback, rei):
     # Generate output
     output = generate_csv(results) if params['mode'] == 'csv' else generate_human_output(results)
     callback.writeLine("stdout", output)
-    
+
 INPUT *data_package="", *log_loc="", *offline="", *no_datacite="", *mode=""
 OUTPUT ruleExecOut

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -49,21 +49,33 @@ def generate_human_output(results):
     return '\n\n'.join(output).encode('utf-8')
 
 def main(rule_args, callback, rei):
-    # Prepare input parameters
     params = {
         'data_package': global_vars["*data_package"].strip('"'),
+        'log_loc': global_vars["*log_loc"].strip('"'),
+        'offline': global_vars["*offline"].strip('"'),
+        'no_datacite': global_vars["*no_datacite"].strip('"'),
         'mode': global_vars["*mode"].strip('"').lower()
     }
     
-    # Run Python troubleshooting rule
-    ret_val = callback.rule_batch_troubleshoot_published_data_packages(
-        params['data_package'], "", "", "", params['mode'], ""
-    )
-    results = json.loads(ret_val["arguments"][5])
+    # Validate mode before proceeding
+    if params['mode'] not in ('human', 'csv'):
+        raise ValueError("Invalid mode. Use 'human' or 'csv'")
 
-    # Generate output
+    # Execute troubleshooting with all parameters
+    ret_val = callback.rule_batch_troubleshoot_published_data_packages(
+        params['data_package'],
+        params['log_loc'],
+        params['offline'],
+        params['no_datacite'],
+        params['mode'],
+        ""  # Output placeholder
+    )
+    
+    # Process and output results
+    results = json.loads(ret_val["arguments"][5])
     output = generate_csv(results) if params['mode'] == 'csv' else generate_human_output(results)
     callback.writeLine("stdout", output)
+
 
 INPUT *data_package="", *log_loc="", *offline="", *no_datacite="", *mode=""
 OUTPUT ruleExecOut

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -5,7 +5,7 @@ import io
 import json
 
 HEADERS = [
-    "Package", 
+    "Package",
     "Schema Check",
     "Missing AVUs Check",
     "Unexpected AVUs Check",
@@ -15,12 +15,13 @@ HEADERS = [
     "Combi JSON Check"
 ]
 
+
 def generate_csv(results):
     """Generate CSV output from troubleshooting results"""
     output = io.StringIO()
     writer = csv.writer(output)
     writer.writerow(HEADERS)
-    
+
     for package in sorted(results.keys()):
         res = results[package]
         row = [package]
@@ -30,8 +31,9 @@ def generate_csv(results):
             value = res.get(field, 'N/A')
             row.append(str(value) if value not in ('Pass', 'Fail') else value)
         writer.writerow(row)
-    
+
     return output.getvalue().encode('utf-8')
+
 
 def generate_human_output(results):
     """Generate human-readable output from troubleshooting results"""
@@ -39,25 +41,26 @@ def generate_human_output(results):
     for package in sorted(results.keys()):
         res = results[package]
         present_fields = [field for field in HEADERS[1:] if field in res]
-        
+
         status_line = (
             "Package passed all tests."
             if all(res[field] == 'Pass' for field in present_fields)
             else "Package FAILED one or more tests:"
         )
-        
+
         section = [
             f"Troubleshooting Results for: {package}",
             status_line
         ]
-        
+
         if "FAILED" in status_line:
             for field in present_fields:
                 section.append(f"{field}: {res[field]}")
-        
+
         output.append('\n'.join(section))
-    
+
     return '\n\n'.join(output).encode('utf-8')
+
 
 def main(rule_args, callback, rei):
     params = {
@@ -67,7 +70,7 @@ def main(rule_args, callback, rei):
         'no_datacite': global_vars["*no_datacite"].strip('"'),
         'mode': global_vars["*mode"].strip('"').lower()
     }
-    
+
     # Execute troubleshooting with all parameters
     ret_val = callback.rule_batch_troubleshoot_published_data_packages(
         params['data_package'],
@@ -77,7 +80,7 @@ def main(rule_args, callback, rei):
         params['mode'],
         ""  # Output placeholder
     )
-    
+
     # Process and output results
     results = json.loads(ret_val["arguments"][5])
     output = generate_csv(results) if params['mode'] == 'csv' else generate_human_output(results)

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -1,11 +1,64 @@
 #!/usr/bin/irule -r irods_rule_engine_plugin-python-instance -F
 
-def main(rule_args, callback, rei):
+#TODO: WHy use bytesIO not stringIO
+# Save to a CSV file or output in CSV? If to a file, any example?
+import csv
+import io
+import json
+
+def main(rule_args, callback, rei): # TODO: Shall we Use rule_args? 
+    # Read input parameters
     data_package = global_vars["*data_package"].strip('"')
     log_loc = global_vars["*log_loc"].strip('"')
     offline = global_vars["*offline"].strip('"')
     no_datacite = global_vars["*no_datacite"].strip('"')
-    callback.rule_batch_troubleshoot_published_data_packages(data_package, log_loc, offline, no_datacite)
 
+    # Get raw JSON results from Python rule
+    ret_val = callback.rule_batch_troubleshoot_published_data_packages(
+        data_package,
+        log_loc,
+        offline,
+        no_datacite,
+        ""
+    )
+    results = json.loads(ret_val["arguments"][4])
+    callback.writeLine("stdout log_loc", log_loc.encode('utf-8'))
+    output = io.StringIO()
+    writer = csv.writer(output)
+
+    # Write CSV header
+    writer.writerow([
+        "Package", 
+        "Schema Check",
+        "Missing AVUs Check",
+        "Unexpected AVUs Check",
+        "Version DOI Check",
+        "Base DOI Check",
+        "Landing Page Check",
+        "Combi JSON Check"
+    ])
+    callback.writeLine("stdout", output.getvalue().strip().encode('utf-8'))
+    output.seek(0)
+    output.truncate()
+
+    # Write CSV rows
+    for package in sorted(results.keys()):
+        res = results[package]
+        writer.writerow([
+            package,
+            str(res.get('schema_check', 'N/A')),
+            str(res.get('no_missing_AVUs_check', 'N/A')),
+            str(res.get('no_unexpected_AVUs_check', 'N/A')),
+            str(res.get('versionDOI_check', 'N/A')),
+            str(res.get('baseDOI_check', 'N/A')),
+            str(res.get('landingPage_check', 'N/A')),
+            str(res.get('combiJson_check', 'N/A'))
+        ])
+        callback.writeLine("stdout", output.getvalue().strip().encode('utf-8'))
+        output.seek(0)
+        output.truncate()
+    # return CSV format # TODO: Check with Sietse: Flag to CSV or readable formats # Example: Irods consistency checker 
+    # TODO: Remove path (only keeping the package name in CSV output)
+    # TODO: check with sietse: use Pass or Fail # Use it for both readable and CSV output
 INPUT *data_package="", *log_loc="", *offline="", *no_datacite=""
 OUTPUT ruleExecOut

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -1,19 +1,17 @@
 #!/usr/bin/irule -r irods_rule_engine_plugin-python-instance -F
 
-#TODO: WHy use bytesIO not stringIO
-# Save to a CSV file or output in CSV? If to a file, any example?
 import csv
 import io
 import json
 
-def main(rule_args, callback, rei): # TODO: Shall we Use rule_args? 
+def main(rule_args, callback, rei):
     # Read input parameters
     data_package = global_vars["*data_package"].strip('"')
     log_loc = global_vars["*log_loc"].strip('"')
     offline = global_vars["*offline"].strip('"')
     no_datacite = global_vars["*no_datacite"].strip('"')
 
-    # Get raw JSON results from Python rule
+    # Get processed JSON results from Python rule
     ret_val = callback.rule_batch_troubleshoot_published_data_packages(
         data_package,
         log_loc,
@@ -21,8 +19,11 @@ def main(rule_args, callback, rei): # TODO: Shall we Use rule_args?
         no_datacite,
         ""
     )
+    
+    # Load converted results with Pass/Fail values
     results = json.loads(ret_val["arguments"][4])
-    callback.writeLine("stdout log_loc", log_loc.encode('utf-8'))
+
+    # Create text buffer and CSV writer
     output = io.StringIO()
     writer = csv.writer(output)
 
@@ -46,19 +47,17 @@ def main(rule_args, callback, rei): # TODO: Shall we Use rule_args?
         res = results[package]
         writer.writerow([
             package,
-            str(res.get('schema_check', 'N/A')),
-            str(res.get('no_missing_AVUs_check', 'N/A')),
-            str(res.get('no_unexpected_AVUs_check', 'N/A')),
-            str(res.get('versionDOI_check', 'N/A')),
-            str(res.get('baseDOI_check', 'N/A')),
-            str(res.get('landingPage_check', 'N/A')),
-            str(res.get('combiJson_check', 'N/A'))
+            res.get('schema_check', 'N/A'),
+            res.get('no_missing_AVUs_check', 'N/A'),
+            res.get('no_unexpected_AVUs_check', 'N/A'),
+            res.get('versionDOI_check', 'N/A'),
+            res.get('baseDOI_check', 'N/A'),
+            res.get('landingPage_check', 'N/A'),
+            res.get('combiJson_check', 'N/A')
         ])
         callback.writeLine("stdout", output.getvalue().strip().encode('utf-8'))
         output.seek(0)
         output.truncate()
-    # return CSV format # TODO: Check with Sietse: Flag to CSV or readable formats # Example: Irods consistency checker 
-    # TODO: Remove path (only keeping the package name in CSV output)
-    # TODO: check with sietse: use Pass or Fail # Use it for both readable and CSV output
+
 INPUT *data_package="", *log_loc="", *offline="", *no_datacite=""
 OUTPUT ruleExecOut

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -31,6 +31,7 @@ def generate_human_output(results):
     """Generate human-readable output from results"""
     output = []
     for package in sorted(results.keys()):
+        # log.write(ctx, "Troubleshooting data package: {}".format(data_package), write_stdout) #TODO: how to add this to output?
         res = results[package]
         section = [
             f"Results for: {package}",

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -5,7 +5,6 @@ import io
 import json
 
 def main(rule_args, callback, rei):
-    # Read input parameters
     data_package = global_vars["*data_package"].strip('"')
     log_loc = global_vars["*log_loc"].strip('"')
     offline = global_vars["*offline"].strip('"')
@@ -20,10 +19,9 @@ def main(rule_args, callback, rei):
         ""
     )
     
-    # Load converted results with Pass/Fail values
     results = json.loads(ret_val["arguments"][4])
 
-    # Create text buffer and CSV writer
+    # Create text buffer
     output = io.StringIO()
     writer = csv.writer(output)
 

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -22,7 +22,12 @@ def generate_csv(results):
     writer.writerow(HEADERS)
     
     for package in sorted(results.keys()):
-        row = [package] + [results[package].get(field, 'N/A') for field in HEADERS[1:]]
+        res = results[package]
+        row = [package]
+        for field in HEADERS[1:]:
+            # Get value or N/A if missing
+            value = res.get(field, 'N/A')
+            row.append(str(value) if value not in ('Pass', 'Fail') else value)
         writer.writerow(row)
     
     return output.getvalue().encode('utf-8')
@@ -32,17 +37,22 @@ def generate_human_output(results):
     output = []
     for package in sorted(results.keys()):
         res = results[package]
+        present_fields = [field for field in HEADERS[1:] if field in res]
+        
+        status_line = (
+            "Package passed all tests." 
+            if all(res[field] == 'Pass' for field in present_fields) 
+            else "Package FAILED one or more tests:"
+        )
+        
         section = [
             f"Results for: {package}",
-            "Package passed all tests." if all(
-                res.get(field, 'N/A') == 'Pass' 
-                for field in HEADERS[1:]  # Skip Package
-            ) else "Package FAILED one or more tests:"
+            status_line
         ]
         
-        if "FAILED" in section[-1]:
-            for field in HEADERS[1:]:  # Skip Package
-                section.append(f"{field}: {res.get(field, 'N/A')}")
+        if "FAILED" in status_line:
+            for field in present_fields:
+                section.append(f"{field}: {res[field]}")
         
         output.append('\n'.join(section))
     

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -46,7 +46,7 @@ def generate_human_output(results):
         )
         
         section = [
-            f"Results for: {package}",
+            f"Troubleshooting Results for: {package}",
             status_line
         ]
         

--- a/tools/troubleshoot_data.r
+++ b/tools/troubleshoot_data.r
@@ -5,21 +5,25 @@ import io
 import json
 
 def main(rule_args, callback, rei):
+    # Read input parameters
     data_package = global_vars["*data_package"].strip('"')
     log_loc = global_vars["*log_loc"].strip('"')
     offline = global_vars["*offline"].strip('"')
     no_datacite = global_vars["*no_datacite"].strip('"')
+    mode = global_vars["*mode"].strip('"')
+    #callback.writeLine("stdout", mode.encode('utf-8'))
 
-    # Get processed JSON results from Python rule
+    # Pass all parameters to Python rule
     ret_val = callback.rule_batch_troubleshoot_published_data_packages(
         data_package,
         log_loc,
         offline,
         no_datacite,
-        ""
+        mode,
+        "" 
     )
     
-    results = json.loads(ret_val["arguments"][4])
+    results = json.loads(ret_val["arguments"][5])
 
     # Create text buffer
     output = io.StringIO()
@@ -57,5 +61,5 @@ def main(rule_args, callback, rei):
         output.seek(0)
         output.truncate()
 
-INPUT *data_package="", *log_loc="", *offline="", *no_datacite=""
+INPUT *data_package="", *log_loc="", *offline="", *no_datacite="", *mode=""
 OUTPUT ruleExecOut


### PR DESCRIPTION
1. Run in human readable output (by default):
`python3 troubleshoot-published-data.py -m human` or `python3 troubleshoot-published-data.py`
2. Run in CSV output:
`python3 troubleshoot-published-data.py -m csv` 

Documentation update: https://github.com/UtrechtUniversity/yoda/pull/551