### PR TITLE
Update logging functions from iRODS 4.3

### DIFF
--- a/util/api.py
+++ b/util/api.py
@@ -136,20 +136,20 @@ def _api(f: Callable) -> Callable:
             if type(data) is not OrderedDict:
                 raise jsonutil.ParseError('Argument is not a JSON object')
         except base64.binascii.Error:
-            log._write(ctx, 'Error: API rule <{}> input base64 decode error'.format(f.__name__))
+            log.write(ctx, 'Error: API rule <{}> input base64 decode error'.format(f.__name__), print_module=False)
             return bad_request('API input base64 decode error').as_dict()
         except zlib.error:
-            log._write(ctx, 'Error: API rule <{}> input zlib decompression error'.format(f.__name__))
+            log.write(ctx, 'Error: API rule <{}> input zlib decompression error'.format(f.__name__), print_module=False)
             return bad_request('API input zlib decompression error').as_dict()
         except jsonutil.ParseError as e:
-            log._write(ctx, 'Error: API rule <{}> called with invalid JSON argument'.format(f.__name__))
+            log.write(ctx, 'Error: API rule <{}> called with invalid JSON argument'.format(f.__name__), print_module=False)
             return bad_request('JSON parse error: {}'.format(e)).as_dict()
 
         # Check that required arguments are present.
         for param in required:
             if param not in data:
-                log._write(ctx, 'Error: API rule <{}> called with missing <{}> argument'
-                                .format(f.__name__, param))
+                log.write(ctx, 'Error: API rule <{}> called with missing <{}> argument'.format(f.__name__, param),
+                          print_module=False)
                 return bad_request('Missing argument: {} (required: [{}]  optional: [{}])'
                                    .format(param, ', '.join(required), ', '.join(optional))).as_dict()
 
@@ -157,8 +157,8 @@ def _api(f: Callable) -> Callable:
         if not allow_extra:
             for param in data:
                 if param not in required | optional:
-                    log._write(ctx, 'Error: API rule <{}> called with unrecognized <{}> argument'
-                                    .format(f.__name__, param))
+                    log.write(ctx, 'Error: API rule <{}> called with unrecognized <{}> argument'.format(f.__name__, param),
+                              print_module=False)
                     return bad_request('Unrecognized argument: {} (required: [{}]  optional: [{}])'
                                        .format(param, ', '.join(required), ', '.join(optional))).as_dict()
 
@@ -184,14 +184,17 @@ def _api(f: Callable) -> Callable:
         except Error as e:
             # A proper caught error with name and message.
             if e.debug_info is None:
-                log._write(ctx, 'Error: API rule <{}> failed with error <{}>'.format(f.__name__, e))
+                log.write(ctx, 'Error: API rule <{}> failed with error <{}>'.format(f.__name__, e), print_module=False)
             else:
-                log._write(ctx, 'Error: API rule <{}> failed with error <{}> (debug info follows below this line)\n{}'.format(f.__name__, e, e.debug_info))
+                log.write(ctx,
+                          'Error: API rule <{}> failed with error <{}> (debug info follows below this line)\n{}'.format(f.__name__, e, e.debug_info),
+                          print_module=False)
             return e.as_dict()
         except Exception:
             # An uncaught error. Log a trace to aid debugging.
-            log._write(ctx, 'Error: API rule <{}> failed with uncaught error (trace follows below this line)\n{}'
-                            .format(f.__name__, traceback.format_exc()))
+            log.write(ctx,
+                      'Error: API rule <{}> failed with uncaught error (trace follows below this line)\n{}'.format(f.__name__, traceback.format_exc()),
+                      print_module=False)
             return error_internal(traceback.format_exc()).as_dict()
 
     return wrapper

--- a/util/log.py
+++ b/util/log.py
@@ -4,44 +4,31 @@ __copyright__ = 'Copyright (c) 2019-2024, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import inspect
-import sys
 
 import rule
 from config import config
 
-if 'unittest' not in sys.modules:
-    # We don't import the user functions when running unit tests, because then we'll have
-    # to deal with their dependencies. When running unit tests we should use a "None" ctx
-    # or some mocked object.
-    import user
 
-
-def write(ctx: rule.Context, message: str, write_stdout: bool = False) -> None:
+def write(ctx: rule.Context, message: str, write_stdout: bool = False, print_module: bool = True) -> None:
     """Write a message to the log or stdout.
     Includes client name and originating module if writing to log.
 
     :param ctx:          Combined type of a callback and rei struct
     :param message:      Message to write to log
     :param write_stdout: Whether to write to stdout (used for a few of our scripts)
+    :param print_module: Whether to print the calling module in the message (true by default)
     """
-    if write_stdout:
-        ctx.writeLine("stdout", message)
-    else:
+    if print_module:
         stack = inspect.stack()[1]
         module = inspect.getmodule(stack[0])
-        _write(ctx, '[{}] {}'.format(module.__name__.replace("rules_uu.", ""), message))
-
-
-def _write(ctx: rule.Context, message: str) -> None:
-    """Write a message to the log, including the client name (intended for internal use).
-
-    :param ctx:     Combined type of a callback and rei struct
-    :param message: Message to write to log
-    """
-    if type(ctx) is rule.Context:
-        ctx.writeString('serverLog', '{{{}#{}}} {}'.format(*list(user.user_and_zone(ctx)) + [message]))
+        message_to_print = '[{}] {}'.format(module.__name__.replace("rules_uu.", ""), message)
     else:
-        ctx.writeString('serverLog', message)
+        message_to_print = message
+
+    if write_stdout:
+        ctx.writeLine("stdout", message_to_print)
+    else:
+        ctx.writeString("serverLog", message_to_print)
 
 
 def debug(ctx: rule.Context, message: str) -> None:
@@ -51,4 +38,4 @@ def debug(ctx: rule.Context, message: str) -> None:
     :param message: Message to write to log
     """
     if config.environment == 'development':
-        _write(ctx, 'DEBUG: {}'.format(message))
+        ctx.writeString("serverLog", 'DEBUG: {}'.format(message))

--- a/util/policy.py
+++ b/util/policy.py
@@ -81,23 +81,23 @@ def require() -> Callable:
             try:
                 result = f(ctx, *args)
             except api.Error as e:
-                log._write(ctx, '{} failed due to unhandled API error: {}'.format(f.__name__, str(e)))
+                log.write(ctx, '{} failed due to unhandled API error: {}'.format(f.__name__, str(e)), print_module=False)
                 raise
             except Exception as e:
-                log._write(ctx, '{} failed due to unhandled internal error: {}'.format(f.__name__, str(e)))
+                log.write(ctx, '{} failed due to unhandled internal error: {}'.format(f.__name__, str(e)), print_module=False)
                 raise
 
             if isinstance(result, Succeed):
                 return  # succeed the rule (msi "succeed" has no effect here)
             elif isinstance(result, Fail):
-                log._write(ctx, '{} denied: {}'.format(f.__name__, str(result)))
+                log.write(ctx, '{} denied: {}'.format(f.__name__, str(result)), print_module=False)
                 ctx.msiOprDisallowed()
                 raise AssertionError()  # Just in case.
 
             # Require an unambiguous YES from the policy function.
             # Default to fail.
-            log._write(ctx, '{} denied: ambiguous policy result (internal error): {}'
-                            .format(f.__name__, str(result)))
+            log.write(ctx, '{} denied: ambiguous policy result (internal error): {}'.format(f.__name__, str(result)),
+                      print_module=False)
             ctx.msiOprDisallowed()
             raise AssertionError()
         return r


### PR DESCRIPTION
- No longer print user/zone information in log function, since printing user/zone information is now handled by the new log transform script.
- Also make all other parts of the code use the public log.write function rather than calling log._write directly in some places.