### PR TITLE
Add parameter for measuring coverage to ruleset

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install coverage==7.6.7
 
       - name: Run unit tests
         run: |

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -18,7 +18,7 @@ import folder
 import groups
 import meta
 import schema
-from util import avu, collection, config, constants, data_object, group, jsonutil, log, msi, resources, rule, user
+from util import avu, collection, config, constants, data_object, group, jsonutil, log, measure_coverage, msi, resources, rule, user
 
 
 def _call_msvc_stat_vault(ctx, resc_name, data_path):
@@ -794,6 +794,9 @@ def rule_run_integration_tests(ctx, tests):
     :returns: string with test results. Each line has one test name and its verdict.
     """
 
+    if config.measure_coverage:
+        cov = measure_coverage.start_coverage()
+
     return_value = ""
     log.write(ctx, "Running")
 
@@ -831,6 +834,9 @@ def rule_run_integration_tests(ctx, tests):
             verdict = "VERDICT_FAILED   (output '{}')".format(str(result))
 
         return_value += name + " " + verdict + "\n"
+
+    if config.measure_coverage:
+        measure_coverage.stop_coverage(cov)
 
     return return_value
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ redis==3.5.3
 psutil==6.1.1
 iteration_utilities==0.13.0
 sqlcipher3-binary==0.5.4
+coverage==7.8.0

--- a/rules_uu.cfg.template
+++ b/rules_uu.cfg.template
@@ -7,6 +7,7 @@
 
 # Either 'production' or 'development'
 environment                = 'development'
+measure_coverage           = 'false'
 
 resource_primary               = 'irodsResc'
 resource_replica               = 'irodsRescRepl'

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ strictness=short
 docstring_style=sphinx
 max-line-length=127
 exclude=__init__.py,tools,tests/env/
-application-import-names=arb,avu,conftest,util,api,config,constants,data_access_token,datacite,datarequest,data_object,epic,error,folder,groups,groups_import,json_datacite,json_landing_page,jsonutil,log,mail,meta,meta_form,msi,notifications,schema,schema_transformation,schema_transformations,settings,stats,pathutil,provenance,policies_intake,policies_datamanager,policies_datapackage_status,policies_folder_status,policies_datarequest_status,publication,query,replication,revisions,revision_strategies,revision_utils,rule,user,vault,sram,arb_data_manager,cached_data_manager,resources,yoda_names,policies_utils,vault_utils
+application-import-names=arb,avu,conftest,util,api,config,constants,data_access_token,datacite,datarequest,data_object,epic,error,folder,groups,groups_import,json_datacite,json_landing_page,jsonutil,log,mail,meta,meta_form,msi,notifications,schema,schema_transformation,schema_transformations,settings,stats,pathutil,provenance,policies_intake,policies_datamanager,policies_datapackage_status,policies_folder_status,policies_datarequest_status,publication,query,replication,revisions,revision_strategies,revision_utils,rule,user,vault,sram,arb_data_manager,cached_data_manager,resources,yoda_names,policies_utils,vault_utils,measure_coverage
 
 [mypy]
 exclude = tools|unit-tests

--- a/util/api.py
+++ b/util/api.py
@@ -19,6 +19,7 @@ import jsonutil
 import log
 import rule
 from config import config
+from measure_coverage import start_coverage, stop_coverage
 
 
 class Result:
@@ -165,6 +166,9 @@ def _api(f: Callable) -> Callable:
         # Try to run the function with the supplied arguments,
         # catching any error it throws.
         try:
+            if config.measure_coverage:
+                cov = start_coverage()
+
             # Time the request.
             import time
             t = time.time()
@@ -172,6 +176,9 @@ def _api(f: Callable) -> Callable:
             t = time.time() - t
 
             log.debug(ctx, '%4dms %s' % (int(t * 1000), f.__name__))
+
+            if config.measure_coverage:
+                stop_coverage(cov)
 
             if type(result) is Error:
                 raise result  # Allow api.Errors to be either raised or returned.

--- a/util/config.py
+++ b/util/config.py
@@ -74,6 +74,7 @@ class Config:
 
 # Note: Must name all valid config items.
 config = Config(environment=None,
+                measure_coverage=False,
                 default_yoda_schema=None,
                 resource_primary=[],
                 resource_trigger_pol=[],

--- a/util/measure_coverage.py
+++ b/util/measure_coverage.py
@@ -1,0 +1,23 @@
+"""Utility functions for measuring code coverage on development systems."""
+
+__copyright__ = 'Copyright (c) 2019-2025, Utrecht University'
+__license__   = 'GPLv3, see LICENSE'
+
+import os
+
+import coverage
+
+
+def start_coverage():
+    ruleset_path = "/etc/irods/yoda-ruleset"
+    data_file = "/tmp/coverage.dat"
+    source_paths = [ruleset_path, os.path.join(ruleset_path, "util")]
+    cov = coverage.Coverage(source=source_paths, data_file=data_file)
+    cov.set_option("run:parallel", True)
+    cov.start()
+    return cov
+
+
+def stop_coverage(cov):
+    cov.stop()
+    cov.save()


### PR DESCRIPTION
This enables us to measure coverage during testing; we can use this to integrate coverage measurements into our CI workflow for integration and API tests later.