### PR TITLE
YDA-6165: Remove copytovault trigger on ACCEPT

### DIFF
--- a/iiFolderStatusTransitions.r
+++ b/iiFolderStatusTransitions.r
@@ -19,17 +19,6 @@ iiFolderStatus(*folder, *folderStatus) {
 }
 
 
-# \brief Schedule copy-to-vault for just one coll (asynchronously).
-#
-# \param[in]  folder	    Path of folder
-#
-iiScheduleCollCopyToVault(*coll) {
-	delay ("<INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME><PLUSET>1s</PLUSET>") {
-		msiExecCmd("admin-scheduled-copytovault.sh", "", "", "", 0, *out);
-	}
-}
-
-
 # \brief iiFolderDatamanagerAction
 #
 # \param[in] folder

--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -154,10 +154,9 @@ def post_status_transition(ctx: rule.Context,
             message = "Data package accepted for vault"
             notifications.set(ctx, actor, submitter, path, message)
 
-        # Set state to secure package in vault space.
+        # Set state to tell copytovault to secure package in vault space.
         attribute = constants.UUORGMETADATAPREFIX + "cronjob_copy_to_vault"
         avu.set_on_coll(ctx, path, attribute, constants.CRONJOB_STATE['PENDING'])
-        ctx.iiScheduleCollCopyToVault(path)
 
     elif status is constants.research_package_state.FOLDER:
         # If previous action was submit and new status is FOLDER action is unsubmit.

--- a/tools/admin/admin-scheduled-copytovault.sh
+++ b/tools/admin/admin-scheduled-copytovault.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-irule -r irods_rule_engine_plugin-irods_rule_language-instance -F /etc/irods/yoda-ruleset/tools/copy-to-vault.r


### PR DESCRIPTION
API tests for folder and vault pass successfully, even with multiple runs.