### PR TITLE
Fix publication update AVU in DM metadata ingest

### DIFF
--- a/meta.py
+++ b/meta.py
@@ -676,7 +676,7 @@ def rule_meta_datamanager_vault_ingest(rule_args, callback, rei):
         # Add publication update status to vault package.
         # Also used in frontend to check if vault package metadata update is pending.
         try:
-            avu.set_on_coll(ctx, vault_pkg_path, f"{constants.UUORGMETADATAPREFIX}cronjob_vault_ingest", constants.CRONJOB_STATE['PENDING'])
+            avu.set_on_coll(ctx, vault_pkg_path, f"{constants.UUORGMETADATAPREFIX}cronjob_publication_update", constants.CRONJOB_STATE['PENDING'])
             publication.set_update_publication_state(ctx, vault_pkg_path)
         except Exception:
             set_result('FailedToSetPublicationUpdateStatus',


### PR DESCRIPTION
With the workaround for https://github.com/irods/irods/issues/8265, the publication update AVU in the data manager metadata ingest function was changed inadvertently. This resulted in publication updates not being picked up by the publication processing job anymore. This commit restores the correct publication update AVU.