### PR TITLE
YDA-6336: add specific API error for no access permission

### DIFF
--- a/meta_form.py
+++ b/meta_form.py
@@ -176,7 +176,7 @@ def load(ctx: rule.Context, coll: str) -> api.Result:
                 return api.Error('bad_json', 'Please check the structure of this file.', 'JSON invalid')
             except msi.Error as e:
                 if str(e).find("-818000") > -1:
-                    return api.Error('permission_error', 'Action not permitted: no access permission on this file.')
+                    return api.Error('permission_error', 'Action not permitted: no access permission on the metadata file.')
                 else:
                     return api.Error('internal', 'The metadata file could not be read.', e)
 
@@ -254,7 +254,7 @@ def load(ctx: rule.Context, coll: str) -> api.Result:
             return api.Error('bad_json', 'Please check the structure of this file.', 'JSON invalid')
         except msi.Error as e:
             if str(e).find("-818000") > -1:
-                return api.Error('permission_error', 'Action not permitted: no access permission on this file.')
+                return api.Error('permission_error', 'Action not permitted: no access permission on the metadata file.')
             else:
                 return api.Error('internal', 'The metadata file could not be read.', e)
 

--- a/meta_form.py
+++ b/meta_form.py
@@ -175,7 +175,10 @@ def load(ctx: rule.Context, coll: str) -> api.Result:
             except jsonutil.ParseError:
                 return api.Error('bad_json', 'Please check the structure of this file.', 'JSON invalid')
             except msi.Error as e:
-                return api.Error('internal', 'The metadata file could not be read.', e)
+                if str(e).find("-818000") > -1:
+                    return api.Error('permission_error', 'Action not permitted: no access permission on this file.')
+                else:
+                    return api.Error('internal', 'The metadata file could not be read.', e)
 
             # Looks like a valid metadata file.
             # See if its schema is up to date.
@@ -250,7 +253,10 @@ def load(ctx: rule.Context, coll: str) -> api.Result:
         except jsonutil.ParseError:
             return api.Error('bad_json', 'Please check the structure of this file.', 'JSON invalid')
         except msi.Error as e:
-            return api.Error('internal', 'The metadata file could not be read.', e)
+            if str(e).find("-818000") > -1:
+                return api.Error('permission_error', 'Action not permitted: no access permission on this file.')
+            else:
+                return api.Error('internal', 'The metadata file could not be read.', e)
 
         if current_schema_id == schema['$id']:
             # Metadata matches active schema, see if it validates.

--- a/vault.py
+++ b/vault.py
@@ -744,7 +744,7 @@ def api_vault_get_landingpage_data(ctx: rule.Context, coll: str) -> api.Result:
         return api.Error('bad_json', 'Please check the structure of this file.', 'JSON invalid')
     except msi.Error as e:
         if str(e).find("-818000") > -1:
-            return api.Error('permission_error', 'Action not permitted: no access permission on this file.')
+            return api.Error('permission_error', 'Action not permitted: no access permission on the metadata file.')
         else:
             return api.Error('internal', 'The metadata file could not be read.', e)
 

--- a/vault.py
+++ b/vault.py
@@ -743,7 +743,10 @@ def api_vault_get_landingpage_data(ctx: rule.Context, coll: str) -> api.Result:
     except jsonutil.ParseError:
         return api.Error('bad_json', 'Please check the structure of this file.', 'JSON invalid')
     except msi.Error as e:
-        return api.Error('internal', 'The metadata file could not be read.', e)
+        if str(e).find("-818000") > -1:
+            return api.Error('permission_error', 'Action not permitted: no access permission on this file.')
+        else:
+            return api.Error('internal', 'The metadata file could not be read.', e)
 
     # Get deposit date and end preservation date based upon retention period
     # "submitted for vault"


### PR DESCRIPTION
This PR adds a more specific API error for the case of no access permission on metadata file.