### PR TITLE
YDA-6412: add tool script to check data package after migration

### DIFF
--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -242,7 +242,7 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                     if access != "own":  # Any own rights from group collection can be skipped
                         acls_to_add.append(acl)
                 elif acl not in g_acls:
-                    if user_name != "rods" and (user_name != "anonymous" and access == "read"):  # If rods has any rights or anonymous has read rights, they don't have to be removed
+                    if user_name != "rods" and (user_name == "anonymous" and access != "read"):  # If rods has any rights or anonymous has read rights, they don't have to be removed
                         acls_to_remove.append(acl)
                 elif user_name in path and access == "own":  # If group already has own rights on collection/data package, they should be removed
                     acls_to_remove.append(acl)
@@ -252,6 +252,7 @@ def compare_acls(ctx, acls, g_acls, path, mode):
 
                 if len(acls_to_add) > 0:
                     for acl in acls_to_add:
+                        user_id = acl['user_id']
                         user_name = acl['user_name']
                         access = acl['access']
 
@@ -262,10 +263,17 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                             try:
                                 ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
                             except Exception:
-                                ctx.writeString("serverLog", "Something went wrong while setting ACL.")
+                                ctx.writeLine("stdout", "ERROR: Something went wrong while setting ACLs.")
+
+                            if ensure_fix(ctx, "acl-add", path, user_id=user_id, access=access):
+                                ctx.writeLine("stdout", f"\tDone.")
+                            else:
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs.") 
+
 
                 if len(acls_to_remove) > 0:
                     for acl in acls_to_remove:
+                        user_id = acl['user_id']
                         user_name = acl['user_name']
                         access = acl['access']
 
@@ -276,7 +284,12 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                             try:
                                 ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
                             except Exception:
-                                ctx.writeString("serverLog", "Something went wrong while setting ACL.")
+                                ctx.writeLine("stdout", "ERROR: Something went wrong while setting ACL.")
+
+                            if ensure_fix(ctx, "acl-remove", path, user_id=user_id, access=access):
+                                ctx.writeLine("stdout", f"\tDone.")
+                            else:
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACL.") 
             else:
                 ctx.writeLine("stdout", f"OK: ACLs of current collection/data object are correct. (Path: {path})")
     else:
@@ -307,12 +320,17 @@ def check_coll_inheritance(ctx, coll, mode):
         ctx.writeLine("stdout", f"WARN: inheritance is {inheritance}, should be Disabled. (Collection: {coll})")
 
         if mode == "write":
-            ctx.writeLine("stdout", f"Running in {mode} mode, fixing...")
+            ctx.writeLine("stdout", f"\tRunning in {mode} mode, fixing...")
 
             try:
                 ctx.msiSetACL("recursive", "admin:noinherit", "", str(coll))
             except Exception:
-                ctx.writeString("serverLog", "Something went wrong while setting inheritance.")
+                ctx.writeLine("stdout", "ERROR: Something went wrong while setting inheritance.")
+
+            if ensure_fix(ctx, "inheritance", coll):
+                ctx.writeLine("stdout", f"\tDone.")
+            else:
+                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting inheritance.")            
     else:
         ctx.writeLine("stdout", f"ERROR: Could not retrieve collection's inheritance. (Collection: {coll})")
 
@@ -407,8 +425,71 @@ def check_metadata(ctx, coll, mode, user):
                                 ctx.msiModAVUMetadata("-C", str(coll), "set", str(attr), str(new_value), "")
                             except Exception:
                                 ctx.writeLine("stdout", "ERROR: Something went wrong while setting AVU.")
+
+                            if ensure_fix(ctx, "avu", coll, attr=attr, value=new_value):
+                                ctx.writeLine("stdout", f"\tDone.")
+                            else:
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting AVU.")  
                     else:
                         ctx.writeLine("stdout", f"OK: AVU '{attr}' contains zone that matches current zone. (Metadata zone: '{avu_zone}', current zone: '{current_zone}')")
+
+
+def ensure_fix(ctx, op, coll, user_id="", access="", attr="", value=""):
+    """Ensures write operation was successful.
+
+    :param ctx:     Combined type of a callback and rei struct
+    :param op:      Type of operation
+    :param coll:    Collection to check
+    :param user_id: User ID of the user (ACL)
+    :param access:  Access type (ACL)
+    :param attr:    Attribute name (AVU)
+    :param value:   Value of attribute (AVU)
+    """
+    ensured = False
+
+    if access == "read":
+        access = ['read', 'read_object']
+    elif access == "write":
+        access = ['write', 'write_object']
+
+    if op == "acl-add":
+        query = genquery.row_iterator(
+            "COLL_ACCESS_USER_ID, COLL_ACCESS_NAME",
+            f"COLL_ACCESS_USER_ID = '{user_id}' AND COLL_ACCESS_NAME in {access} AND COLL_NAME like '{coll}'",
+            genquery.AS_LIST,
+            ctx)
+
+        if query.total_rows() > 0:
+            ensured = True
+    elif op == "acl-remove":
+        query = genquery.row_iterator(
+            "COLL_ACCESS_USER_ID, COLL_ACCESS_NAME",
+            f"COLL_ACCESS_USER_ID = '{user_id}' AND COLL_ACCESS_NAME in {access} AND COLL_NAME like '{coll}'",
+            genquery.AS_LIST,
+            ctx)
+
+        if not (query.total_rows() > 0):
+            ensured = True
+    elif op == "inheritance":
+        query = genquery.row_iterator(
+                "COLL_INHERITANCE",
+                f"COLL_NAME like '{coll}'",
+                genquery.AS_LIST,
+                ctx)
+
+        if query.total_rows() > 0:
+            for result in query:
+                ensured = True if result[0] == "0" else False
+    elif op == "avu":
+        query = genquery.row_iterator(
+            "META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
+            f"META_COLL_ATTR_NAME like '{attr}' AND META_COLL_ATTR_VALUE like '{value}' AND COLL_NAME = '{coll}'",
+            genquery.AS_LIST,
+            ctx)
+
+        if query.total_rows() > 0:
+            ensured = True
+    return ensured
 
 
 def main(rule_args, ctx, rei):
@@ -418,8 +499,8 @@ def main(rule_args, ctx, rei):
     :param ctx:       iRODS context
     :param rei:       Rule execution information
     """
-    coll = global_vars["*coll"]
-    mode = global_vars["*mode"]
+    coll = global_vars["*coll"].strip('"')
+    mode = global_vars["*mode"].strip('"')
 
     try:
         current_user = ctx.uuClientFullNameWrapper("")['arguments'][0]
@@ -453,12 +534,3 @@ def main(rule_args, ctx, rei):
 
 INPUT *coll=, *mode=read
 OUTPUT ruleExecOut
-
-# (DONE) TODO: Add exception to write mode for "own" rights of group
-# TODO: Test another user
-# TODO: Add sanity check (double check ACLs for specific users)
-# TODO: Add sanity check (rerun check after fix)
-# (DONE) TODO: Add a check so that it only runs on vault packages
-# (DONE) TODO: Reorder arguments so that ctx is always the first argument (similar to the ruleset), except for main
-# (DONE) TODO: Use the same docstyle (Sphinx) for function comments
-# (DONE) TODO: Run flake8 / ruff on the script for linting

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -233,23 +233,25 @@ def compare_acls(ctx, acls, g_acls, path, mode):
             acls_to_remove = []
             acls_to_add = []
 
+            # Join ACLs of both lists
             join_acls = [acl for i, acl in enumerate(acls + g_acls) if acl not in (acls + g_acls)[:i]]
             for acl in join_acls:
                 user_name = acl['user_name']
                 access = acl['access']
 
-                if acl not in acls:
+                if acl not in acls:  # If ACL is in group collection's ACLs but not collection/data object's ACLs, it might need to be added
                     if access != "own":  # Any own rights from group collection can be skipped
                         acls_to_add.append(acl)
-                elif acl not in g_acls:
+                elif acl not in g_acls:  # If ACL is in collection/data object's ACLs but not in group collection's ACLs, it might need to be removed
                     if user_name != "rods" and (user_name == "anonymous" and access != "read"):  # If rods has any rights or anonymous has read rights, they don't have to be removed
                         acls_to_remove.append(acl)
-                elif user_name in path and access == "own":  # If group already has own rights on collection/data package, they should be removed
+                elif user_name in path and access == "own":  # If group already has own rights on collection/data object, they should be removed
                     acls_to_remove.append(acl)
 
             if len(acls_to_add) > 0 or len(acls_to_remove) > 0:
                 ctx.writeLine("stdout", f"WARN: ACLs of current collection/data object have issues. (Path: {path})")
 
+                # Add missing ACLs
                 if len(acls_to_add) > 0:
                     for acl in acls_to_add:
                         user_id = acl['user_id']
@@ -265,11 +267,13 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                             except Exception:
                                 ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs. (Path: {path})")
 
+                            # Ensure write operation was successful
                             if ensure_fix(ctx, "acl-add", path, user_id=user_id, access=access):
                                 ctx.writeLine("stdout", "\tDone.")
                             else:
                                 ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs. (Path: {path})")
 
+                # Remove extra ACLs
                 if len(acls_to_remove) > 0:
                     for acl in acls_to_remove:
                         user_id = acl['user_id']
@@ -285,6 +289,7 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                             except Exception:
                                 ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs. (Path: {path})")
 
+                            # Ensure write operation was successful
                             if ensure_fix(ctx, "acl-remove", path, user_id=user_id, access=access):
                                 ctx.writeLine("stdout", "\tDone.")
                             else:
@@ -313,6 +318,7 @@ def check_coll_inheritance(ctx, coll, mode):
         for result in inherit_query:
             inheritance = "Enabled" if result[0] == "1" else "Disabled"
 
+    # Vault packages should have inheritance disabled
     if inheritance == "Disabled":
         ctx.writeLine("stdout", f"OK: Inheritance is {inheritance}. (Path: {coll})")
     elif inheritance == "Enabled":
@@ -326,6 +332,7 @@ def check_coll_inheritance(ctx, coll, mode):
             except Exception:
                 ctx.writeLine("stdout", f"ERROR: Something went wrong while setting inheritance. (Path: {coll})")
 
+            # Ensure write operation was successful
             if ensure_fix(ctx, "inheritance", coll):
                 ctx.writeLine("stdout", "\tDone.")
             else:
@@ -409,7 +416,8 @@ def check_metadata(ctx, coll, mode, user):
         vault_status = coll_avus['org_vault_status']
         if vault_status == "PUBLISHED" or vault_status == "DEPUBLISHED":
             for (attr, value) in coll_avus.items():
-                if os.path.isabs(value):  # Filter AVUs that refer to a path
+                # Filter AVUs that refer to a path
+                if os.path.isabs(value):
                     current_zone = ctx.uuClientZone("")['arguments'][0]
                     avu_zone = value.split('/')[1]
                     if avu_zone != current_zone:
@@ -419,12 +427,13 @@ def check_metadata(ctx, coll, mode, user):
                             ctx.writeLine("stdout", f"\tRunning in {mode} mode, fixing...")
                             new_value = value.replace(avu_zone, current_zone)
 
+                            # Update zone name
                             try:
-                                # Update zone
                                 ctx.msiModAVUMetadata("-C", str(coll), "set", str(attr), str(new_value), "")
                             except Exception:
                                 ctx.writeLine("stdout", f"ERROR: Something went wrong while setting AVU '{attr}'.")
 
+                            # Ensure write operation was successful
                             if ensure_fix(ctx, "avu", coll, attr=attr, value=new_value):
                                 ctx.writeLine("stdout", "\tDone.")
                             else:
@@ -507,11 +516,11 @@ def main(rule_args, ctx, rei):
         current_user = ctx.uuClientFullNameWrapper("")['arguments'][0]
         current_user_type = ctx.uuGetUserType(current_user, "")['arguments'][1]
     except Exception:
-        ctx.writeString("serverLog", "Something went wrong while retrieving user information.")
+        ctx.writeLine("stdout", "ERROR: Something went wrong while retrieving user information.")
 
-    if current_user_type == 'rodsadmin':
+    if current_user_type == 'rodsadmin':  # Only rodsadmin users can run this script
         if coll_exists(ctx, coll):
-            if 'vault-' in coll:
+            if 'vault-' in coll:  # Script should be run on vault collections only
                 ctx.writeLine("stdout", f"Executing package check rule for collection: {coll} (mode: {mode})")
                 ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -7,8 +7,14 @@ import irods_types
 import os
 
 
-# Determine existence of collection
 def coll_exists(ctx, coll):
+    """Determine existence of a collection.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to determine existence of
+
+    :returns: Boolean indicating existence of the collection
+    """
     exists_query = genquery.row_iterator(
         "COLL_ID",
         "COLL_NAME like '{}'".format(coll),
@@ -21,8 +27,14 @@ def coll_exists(ctx, coll):
         return False
 
 
-# Get user name from user ID
 def get_user_name(ctx, id):
+    """Get user name from user ID.
+
+    :param ctx: Combined type of a callback and rei struct
+    :param id:  User ID of the user
+
+    :returns: User name matching with user ID, empty string if not found
+    """
     user_query = genquery.row_iterator(
         "USER_NAME",
         "USER_ID = '{}'".format(id),
@@ -36,8 +48,14 @@ def get_user_name(ctx, id):
     return user_name
 
 
-# Get group collection
 def get_group_coll(ctx, coll):
+    """Get group from collection.
+
+    :param ctx: Combined type of a callback and rei struct
+    :param coll: Collection to determine group of
+
+    :returns: Name of the group of the collection
+    """
     group_coll = ""
     if coll.rsplit('/', 1)[-1].startswith("vault-"):
         group_coll = coll
@@ -57,8 +75,15 @@ def get_group_coll(ctx, coll):
     return group_coll
 
 
-# Get AVUs from collection
 def get_avus(ctx, coll, avu):
+    """Get AVUs from a collection.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to retrieve AVUs from
+    :param avu:  Attribute to filter AVUs
+
+    :returns: Dictionary of AVUs for the specified collection.
+    """
     avu_query = genquery.row_iterator(
         "ORDER(META_COLL_ATTR_NAME), META_COLL_ATTR_VALUE",
         "META_COLL_ATTR_NAME like '{}' AND COLL_NAME = '{}'".format(avu, coll),
@@ -72,8 +97,14 @@ def get_avus(ctx, coll, avu):
     return avus
 
 
-# Get collection's subcollections
 def get_subcolls(ctx, coll):
+    """Get subcollections of a collection.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to retrieve subcollections from
+
+    :returns: List of subcollection names
+    """
     subcoll_query = genquery.row_iterator(
             "COLL_NAME",
             "COLL_NAME like '{}/%'".format(coll),
@@ -88,8 +119,14 @@ def get_subcolls(ctx, coll):
     return subcolls
 
 
-# Get collection's data objects
 def get_dataobjs(ctx, coll):
+    """Get data objects in a collection.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to retrieve data objects from
+
+    :returns: List of data object names
+    """
     data_query = genquery.row_iterator(
         "DATA_NAME",
         "COLL_NAME like '{}'".format(coll),
@@ -104,8 +141,14 @@ def get_dataobjs(ctx, coll):
     return dataobjs
 
 
-# Get ACLs of collection
 def get_coll_acls(ctx, coll):
+    """Get ACLs of a collection.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to retrieve ACLs from
+
+    :returns: List of user access details for the collection
+    """
     access_query = genquery.row_iterator(
         "ORDER(COLL_ACCESS_USER_ID), COLL_ACCESS_NAME",
         "COLL_NAME like '{}'".format(coll),
@@ -135,8 +178,15 @@ def get_coll_acls(ctx, coll):
     return acl
 
 
-# Get ACLs of data
 def get_data_acls(ctx, coll, data):
+    """Get ACLs of a data object.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection containing the data object
+    :param data: Name of the data object to retrieve ACLs for
+
+    :returns: List of user access details for the data object
+    """
     access_query = genquery.row_iterator(
         "ORDER(DATA_ACCESS_USER_ID), DATA_ACCESS_NAME",
         "COLL_NAME like '{}' AND DATA_NAME like '{}'".format(coll, data),
@@ -167,8 +217,15 @@ def get_data_acls(ctx, coll, data):
     return acl
 
 
-# Compare ACLs
 def compare_acls(ctx, acls, g_acls, path, mode):
+    """Compare ACLs of a collection/data object with group ACLs.
+
+    :param ctx:    Combined type of a callback and rei struct
+    :param acls:   ACLs of the current collection/data object
+    :param g_acls: ACLs of the group collection
+    :param path:   Path of the collection/data object being checked
+    :param mode:   Mode of operation (read or write)
+    """
     if len(g_acls) > 0 and len(acls) > 0:
         if (acls == g_acls):
             ctx.writeLine("stdout", "OK: ACLs of current collection/data object are correct. (Path: {})".format(path))
@@ -226,8 +283,13 @@ def compare_acls(ctx, acls, g_acls, path, mode):
         ctx.writeLine("stdout", "ERROR: No ACLs found for this collection/data object. (Path: {})".format(path))
 
 
-# Check inheritance of collection
 def check_coll_inheritance(ctx, coll, mode):
+    """Check inheritance of a collection.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to check inheritance for
+    :param mode: Mode of operation (read or write)
+    """
     inherit_query = genquery.row_iterator(
         "COLL_INHERITANCE",
         "COLL_NAME like '{}'".format(coll),
@@ -255,8 +317,13 @@ def check_coll_inheritance(ctx, coll, mode):
         ctx.writeLine("stdout", "ERROR: Could not retrieve collection's inheritance. (Collection: {})".format(coll))
 
 
-# Check ACLs
 def check_acls(ctx, coll, mode):
+    """Check ACLs of a collection and its data objects.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to check ACLs for
+    :param mode: Mode of operation (read or write)
+    """
     # Get group collection
     group_coll = get_group_coll(ctx, coll)
 
@@ -293,8 +360,13 @@ def check_acls(ctx, coll, mode):
         ctx.writeLine("stdout", "ERROR: Could not retrieve group collection.")
 
 
-# Check inheritance
 def check_inheritance(ctx, coll, mode):
+    """Check inheritance of a collection and its subcollections.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to check inheritance for
+    :param mode: Mode of operation (read or write)
+    """
     # Inheritance should be disabled on vault packages
     # Check inheritance of collection
     coll_inherit = check_coll_inheritance(ctx, coll, mode)
@@ -308,6 +380,13 @@ def check_inheritance(ctx, coll, mode):
 
 
 def check_metadata(ctx, coll, mode, user):
+    """Check and update metadata for a collection.
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Collection to check metadata for
+    :param mode: Mode of operation (read or write)
+    :param user: User performing the operation
+    """
     # if vault status "PUBLISHED" or "DEPUBLISHED"
         # if AVU refers to Yoda collection, update zone name
         # if DOI record exists at DataCite, update URL
@@ -351,6 +430,12 @@ def check_metadata(ctx, coll, mode, user):
 
 
 def main(rule_args, ctx, rei):
+    """Main function to execute the package check rule.
+
+    :param rule_args: Arguments passed to the rule
+    :param ctx:       iRODS context
+    :param rei:       Rule execution information
+    """
     coll = global_vars["*coll"]
     mode = global_vars["*mode"]
 
@@ -392,5 +477,5 @@ OUTPUT ruleExecOut
 # TODO: Add sanity check (rerun check after fix)
 # (DONE) TODO: Add a check so that it only runs on vault packages
 # (DONE) TODO: Reorder arguments so that ctx is always the first argument (similar to the ruleset), except for main
-# TODO: Use the same docstyle (Sphinx) for function comments
+# (DONE) TODO: Use the same docstyle (Sphinx) for function comments
 # TODO: Run flake8 / ruff on the script for linting

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -3,6 +3,7 @@
 # irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/package-check.r '*coll=' '*mode='
 #
 import genquery
+import irods_types
 import os
 
 
@@ -330,7 +331,7 @@ def check_metadata(coll, mode, user, ctx):
                                 ctx.msiSetACL("recursive", "admin:write", str(user), str(coll))
 
                                 # Update zone
-                                out = ctx.msiString2KeyValPair("{}={}".format(str(attr), str(new_value)), 0)
+                                out = ctx.msiString2KeyValPair("{}={}".format(str(attr), str(new_value)), irods_types.KeyValPair())
                                 kvp = out['arguments'][1]
                                 ctx.msiSetKeyValuePairsToObj(kvp, coll, '-C')
 

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -2,14 +2,15 @@
 #
 # Checks data package for incorrect ACLs and/or AVUs after migration.
 #
-# Usage: 
+# Usage:
 # $ irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/package-check.r '*coll=/example/package' '*mode=read/write'
 #
 # *coll: path of the collection to be checked
 # *mode: read (report only), write (report and fix)
 #
-import genquery
 import os
+
+import genquery
 
 
 def coll_exists(ctx, coll):
@@ -111,10 +112,10 @@ def get_subcolls(ctx, coll):
     :returns: List of subcollection names, empty list if none found
     """
     subcoll_query = genquery.row_iterator(
-            "COLL_NAME",
-            "COLL_NAME like '{}/%'".format(coll),
-            genquery.AS_LIST,
-            ctx)
+        "COLL_NAME",
+        "COLL_NAME like '{}/%'".format(coll),
+        genquery.AS_LIST,
+        ctx)
 
     subcolls = []
     if subcoll_query.total_rows() > 0:
@@ -175,7 +176,6 @@ def get_coll_acls(ctx, coll):
             else:
                 user_access['access'] = access
 
-
             acl.append(user_access)
         # for item in acl:
         #     for key, value in item.items():
@@ -213,7 +213,6 @@ def get_data_acls(ctx, coll, data):
             else:
                 user_access['access'] = access
 
-
             acl.append(user_access)
 
         # for item in acl:
@@ -244,12 +243,12 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                 access = acl['access']
 
                 if acl not in acls:
-                    if access != "own": # Any own rights from group collection can be skipped
+                    if access != "own":  # Any own rights from group collection can be skipped
                         acls_to_add.append(acl)
                 elif acl not in g_acls:
-                    if user_name != "rods" and (user_name != "anonymous" and access == "read"): # If rods has any rights or anonymous has read rights, they don't have to be removed
+                    if user_name != "rods" and (user_name != "anonymous" and access == "read"):  # If rods has any rights or anonymous has read rights, they don't have to be removed
                         acls_to_remove.append(acl)
-                elif user_name in path and access == "own": # If group already has own rights on collection/data package, they should be removed
+                elif user_name in path and access == "own":  # If group already has own rights on collection/data package, they should be removed
                     acls_to_remove.append(acl)
 
             if len(acls_to_add) > 0 or len(acls_to_remove) > 0:
@@ -260,7 +259,7 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                         user_name = acl['user_name']
                         access = acl['access']
 
-                        ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to the group collection but not to this collection/data object, and should have those rights.".format(acl['user_name'], acl['access']))                    
+                        ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to the group collection but not to this collection/data object, and should have those rights.".format(acl['user_name'], acl['access']))
 
                         if mode == "write":
                             ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
@@ -273,9 +272,9 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                     for acl in acls_to_remove:
                         user_name = acl['user_name']
                         access = acl['access']
-                        
+
                         ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to this collection/data object, but should not have those rights.".format(acl['user_name'], acl['access']))
-                        
+
                         if mode == "write":
                             ctx.writeLine("stdout", "\tRunning in {} mode, removing extra ACLs...".format(mode))
                             try:
@@ -373,14 +372,14 @@ def check_inheritance(ctx, coll, mode):
     :param mode: Mode of operation (read or write)
     """
     # Check inheritance of collection
-    coll_inherit = check_coll_inheritance(ctx, coll, mode)
+    check_coll_inheritance(ctx, coll, mode)
 
     # Check inheritance of collection's subcollections
     subcolls = get_subcolls(ctx, coll)
 
     if len(subcolls) > 0:
         for subcoll in subcolls:
-            subcoll_inherit = check_coll_inheritance(ctx, subcoll, mode)
+            check_coll_inheritance(ctx, subcoll, mode)
 
 
 def check_metadata(ctx, coll, mode, user):
@@ -397,7 +396,7 @@ def check_metadata(ctx, coll, mode, user):
         vault_status = coll_avus['org_vault_status']
         if vault_status == "PUBLISHED" or vault_status == "DEPUBLISHED":
             for (attr, value) in coll_avus.items():
-                if os.path.isabs(value): # Filter AVUs that refer to a path
+                if os.path.isabs(value):  # Filter AVUs that refer to a path
                     current_zone = ctx.uuClientZone("")['arguments'][0]
                     avu_zone = value.split('/')[1]
                     if avu_zone != current_zone:
@@ -466,4 +465,4 @@ OUTPUT ruleExecOut
 # (DONE) TODO: Add a check so that it only runs on vault packages
 # (DONE) TODO: Reorder arguments so that ctx is always the first argument (similar to the ruleset), except for main
 # (DONE) TODO: Use the same docstyle (Sphinx) for function comments
-# TODO: Run flake8 / ruff on the script for linting
+# (DONE) TODO: Run flake8 / ruff on the script for linting

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -454,6 +454,8 @@ def ensure_fix(ctx, op, coll, user_id="", access="", attr="", value=""):
     :param access:  Access type (ACL)
     :param attr:    Attribute name (AVU)
     :param value:   Value of attribute (AVU)
+
+    :returns: Boolean indicating if write operation was successful
     """
     ensured = False
 
@@ -489,7 +491,7 @@ def ensure_fix(ctx, op, coll, user_id="", access="", attr="", value=""):
 
         if query.total_rows() > 0:
             for result in query:
-                ensured = True if result[0] == "0" else False
+                ensured = result[0] == "0"
     elif op == "avu":
         query = genquery.row_iterator(
             "META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
@@ -542,5 +544,5 @@ def main(rule_args, ctx, rei):
     else:
         ctx.writeLine("stdout", "ERROR: This rule can only be run by a rodsadmin user.")
 
-INPUT *coll=, *mode=read
-OUTPUT ruleExecOut
+#INPUT *coll=, *mode=read
+#OUTPUT ruleExecOut

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -8,7 +8,7 @@ import os
 
 
 # Determine existence of collection
-def coll_exists(coll, ctx):
+def coll_exists(ctx, coll):
     exists_query = genquery.row_iterator(
         "COLL_ID",
         "COLL_NAME like '{}'".format(coll),
@@ -22,7 +22,7 @@ def coll_exists(coll, ctx):
 
 
 # Get user name from user ID
-def get_user_name(id, ctx):
+def get_user_name(ctx, id):
     user_query = genquery.row_iterator(
         "USER_NAME",
         "USER_ID = '{}'".format(id),
@@ -37,7 +37,7 @@ def get_user_name(id, ctx):
 
 
 # Get group collection
-def get_group_coll(coll, ctx):
+def get_group_coll(ctx, coll):
     group_coll = ""
     if coll.rsplit('/', 1)[-1].startswith("vault-"):
         group_coll = coll
@@ -53,12 +53,12 @@ def get_group_coll(coll, ctx):
                 if result[0].rsplit('/', 1)[-1].startswith("vault-"):
                     group_coll = result[0]
                 else:   # If parent collection is not group collection, go up another level
-                    group_coll = get_group_coll(group_coll, ctx)
+                    group_coll = get_group_coll(ctx, group_coll)
     return group_coll
 
 
 # Get AVUs from collection
-def get_avus(coll, avu, ctx):
+def get_avus(ctx, coll, avu):
     avu_query = genquery.row_iterator(
         "ORDER(META_COLL_ATTR_NAME), META_COLL_ATTR_VALUE",
         "META_COLL_ATTR_NAME like '{}' AND COLL_NAME = '{}'".format(avu, coll),
@@ -73,7 +73,7 @@ def get_avus(coll, avu, ctx):
 
 
 # Get collection's subcollections
-def get_subcolls(coll, ctx):
+def get_subcolls(ctx, coll):
     subcoll_query = genquery.row_iterator(
             "COLL_NAME",
             "COLL_NAME like '{}/%'".format(coll),
@@ -89,7 +89,7 @@ def get_subcolls(coll, ctx):
 
 
 # Get collection's data objects
-def get_dataobjs(coll, ctx):
+def get_dataobjs(ctx, coll):
     data_query = genquery.row_iterator(
         "DATA_NAME",
         "COLL_NAME like '{}'".format(coll),
@@ -105,7 +105,7 @@ def get_dataobjs(coll, ctx):
 
 
 # Get ACLs of collection
-def get_coll_acls(coll, ctx):
+def get_coll_acls(ctx, coll):
     access_query = genquery.row_iterator(
         "ORDER(COLL_ACCESS_USER_ID), COLL_ACCESS_NAME",
         "COLL_NAME like '{}'".format(coll),
@@ -118,7 +118,7 @@ def get_coll_acls(coll, ctx):
             user_access = {}
 
             user_access['user_id'] = user
-            user_access['user_name'] = get_user_name(user, ctx)
+            user_access['user_name'] = get_user_name(ctx, user)
 
             if access == "read_object":
                 user_access['access'] = "read"
@@ -136,7 +136,7 @@ def get_coll_acls(coll, ctx):
 
 
 # Get ACLs of data
-def get_data_acls(coll, data, ctx):
+def get_data_acls(ctx, coll, data):
     access_query = genquery.row_iterator(
         "ORDER(DATA_ACCESS_USER_ID), DATA_ACCESS_NAME",
         "COLL_NAME like '{}' AND DATA_NAME like '{}'".format(coll, data),
@@ -149,7 +149,7 @@ def get_data_acls(coll, data, ctx):
             user_access = {}
 
             user_access['user_id'] = user
-            user_access['user_name'] = get_user_name(user, ctx)
+            user_access['user_name'] = get_user_name(ctx, user)
 
             if access == "read_object":
                 user_access['access'] = "read"
@@ -168,7 +168,7 @@ def get_data_acls(coll, data, ctx):
 
 
 # Compare ACLs
-def compare_acls(acls, g_acls, path, mode, ctx):
+def compare_acls(ctx, acls, g_acls, path, mode):
     if len(g_acls) > 0 and len(acls) > 0:
         if (acls == g_acls): # TODO: ensure check makes sense?
             ctx.writeLine("stdout", "OK: ACLs of current collection/data object match group ACLs. (Path: {})".format(path))
@@ -217,7 +217,7 @@ def compare_acls(acls, g_acls, path, mode, ctx):
 
 
 # Check inheritance of collection
-def check_coll_inheritance(coll, mode, ctx):
+def check_coll_inheritance(ctx, coll, mode):
     inherit_query = genquery.row_iterator(
         "COLL_INHERITANCE",
         "COLL_NAME like '{}'".format(coll),
@@ -246,64 +246,64 @@ def check_coll_inheritance(coll, mode, ctx):
 
 
 # Check ACLs
-def check_acls(coll, mode, ctx):
+def check_acls(ctx, coll, mode):
     # Get group collection
-    group_coll = get_group_coll(coll, ctx)
+    group_coll = get_group_coll(ctx, coll)
 
     if group_coll != "":
         # Check ACLs of provided collection
-        group_acls = get_coll_acls(group_coll, ctx)
-        coll_acls = get_coll_acls(coll, ctx)
-        compare_acls(coll_acls, group_acls, coll, mode, ctx)
+        group_acls = get_coll_acls(ctx, group_coll)
+        coll_acls = get_coll_acls(ctx, coll)
+        compare_acls(ctx, coll_acls, group_acls, coll, mode)
 
         # Check ACLs of provided collection's data objects
-        dataobjs = get_dataobjs(coll, ctx)
+        dataobjs = get_dataobjs(ctx, coll)
 
         if len(dataobjs) > 0:
             for data_obj in dataobjs:
-                dataobj_acls = get_data_acls(coll, data_obj, ctx)
-                compare_acls(dataobj_acls, group_acls, "{}/{}".format(coll, data_obj), mode, ctx)
+                dataobj_acls = get_data_acls(ctx, coll, data_obj)
+                compare_acls(ctx, dataobj_acls, group_acls, "{}/{}".format(coll, data_obj), mode)
 
         # Check ACLs of provided collection's subcollections
-        subcolls = get_subcolls(coll, ctx)
+        subcolls = get_subcolls(ctx, coll)
 
         if len(subcolls) > 0:
             for subcoll in subcolls:
-                subcoll_acls = get_coll_acls(subcoll, ctx)
-                compare_acls(subcoll_acls, group_acls, subcoll, mode, ctx)
+                subcoll_acls = get_coll_acls(ctx, subcoll)
+                compare_acls(ctx, subcoll_acls, group_acls, subcoll, mode)
 
             # Check ACLs of provided collection's subcollections' data objects
-            subcoll_dataobjs = get_dataobjs(subcoll, ctx)
+            subcoll_dataobjs = get_dataobjs(ctx, subcoll)
 
             if len(subcoll_dataobjs) > 0:
                 for subcoll_dataobj in subcoll_dataobjs:
-                    subcoll_dataobj_acls = get_data_acls(subcoll, subcoll_dataobj, ctx)
-                    compare_acls(subcoll_dataobj_acls, group_acls, "{}/{}".format(subcoll, subcoll_dataobj), mode, ctx)
+                    subcoll_dataobj_acls = get_data_acls(ctx, subcoll, subcoll_dataobj)
+                    compare_acls(ctx, subcoll_dataobj_acls, group_acls, "{}/{}".format(subcoll, subcoll_dataobj), mode)
     else:
         ctx.writeLine("stdout", "ERROR: Could not retrieve group collection.")
 
 
 # Check inheritance
-def check_inheritance(coll, mode, ctx):
+def check_inheritance(ctx, coll, mode):
     # Inheritance should be disabled on vault packages
     # Check inheritance of collection
-    coll_inherit = check_coll_inheritance(coll, mode, ctx)
+    coll_inherit = check_coll_inheritance(ctx, coll, mode)
 
     # Check inheritance of collection's subcollections
-    subcolls = get_subcolls(coll, ctx)
+    subcolls = get_subcolls(ctx, coll)
 
     if len(subcolls) > 0:
         for subcoll in subcolls:
-            subcoll_inherit = check_coll_inheritance(subcoll, mode, ctx)
+            subcoll_inherit = check_coll_inheritance(ctx, subcoll, mode)
 
 
-def check_metadata(coll, mode, user, ctx):
+def check_metadata(ctx, coll, mode, user):
     # if vault status "PUBLISHED" or "DEPUBLISHED"
         # if AVU refers to Yoda collection, update zone name
         # if DOI record exists at DataCite, update URL
         # call update-publications.r on package
 
-    coll_avus = get_avus(coll, "org_%", ctx)
+    coll_avus = get_avus(ctx, coll, "org_%")
 
     if bool(coll_avus):
         vault_status = coll_avus['org_vault_status']
@@ -357,21 +357,21 @@ def main(rule_args, ctx, rei):
         ctx.writeString("serverLog", "Something went wrong while retrieving user information.")
 
     if current_user_type == 'rodsadmin':
-        if coll_exists(coll,ctx):
+        if coll_exists(ctx, coll):
             if 'vault-' in coll:
                 ctx.writeLine("stdout", "Executing package check rule for collection: {} (mode: {})".format(coll, mode))
                 ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
                 # Check if collection ACLs match group ACLs
-                check_acls(coll, mode, ctx)
+                check_acls(ctx, coll, mode)
                 ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
                 # Check collection inheritance
-                check_inheritance(coll, mode, ctx)
+                check_inheritance(ctx, coll, mode)
                 ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
                 # Update metadata
-                check_metadata(coll, mode, current_user, ctx)
+                check_metadata(ctx, coll, mode, current_user)
             else:
                 ctx.writeLine("stdout", "ERROR: This rule should be run on vault collections only.")
         else:
@@ -386,6 +386,6 @@ OUTPUT ruleExecOut
 # TODO: Add sanity check (double check ACLs for specific users)
 # TODO: Add sanity check (rerun check after fix)
 # (DONE) TODO: Add a check so that it only runs on vault packages
-# TODO: Reorder arguments so that ctx is always the first argument (similar to the ruleset), except for main
+# (DONE) TODO: Reorder arguments so that ctx is always the first argument (similar to the ruleset), except for main
 # TODO: Use the same docstyle (Sphinx) for function comments
 # TODO: Run flake8 / ruff on the script for linting

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -256,20 +256,19 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                         user_name = acl['user_name']
                         access = acl['access']
 
-                        ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to the group collection but not to this collection/data object, and should have those rights.".format(acl['user_name'], acl['access']))
+                        ctx.writeLine("stdout", f"\tUser/group '{user_name}' has '{access}' rights to the group collection but not to this collection/data object, and should have those rights.")
 
                         if mode == "write":
                             ctx.writeLine("stdout", f"\tRunning in {mode} mode, adding missing ACLs...")
                             try:
                                 ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
                             except Exception:
-                                ctx.writeLine("stdout", "ERROR: Something went wrong while setting ACLs.")
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs. (Path: {path})")
 
                             if ensure_fix(ctx, "acl-add", path, user_id=user_id, access=access):
-                                ctx.writeLine("stdout", f"\tDone.")
+                                ctx.writeLine("stdout", "\tDone.")
                             else:
-                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs.") 
-
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs. (Path: {path})")
 
                 if len(acls_to_remove) > 0:
                     for acl in acls_to_remove:
@@ -277,19 +276,19 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                         user_name = acl['user_name']
                         access = acl['access']
 
-                        ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to this collection/data object, but should not have those rights.".format(acl['user_name'], acl['access']))
+                        ctx.writeLine("stdout", f"\tUser/group '{user_name}' has '{access}' rights to this collection/data object, but should not have those rights.")
 
                         if mode == "write":
                             ctx.writeLine("stdout", f"\tRunning in {mode} mode, removing extra ACLs...")
                             try:
                                 ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
                             except Exception:
-                                ctx.writeLine("stdout", "ERROR: Something went wrong while setting ACL.")
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs. (Path: {path})")
 
                             if ensure_fix(ctx, "acl-remove", path, user_id=user_id, access=access):
-                                ctx.writeLine("stdout", f"\tDone.")
+                                ctx.writeLine("stdout", "\tDone.")
                             else:
-                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACL.") 
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting ACLs. (Path: {path})")
             else:
                 ctx.writeLine("stdout", f"OK: ACLs of current collection/data object are correct. (Path: {path})")
     else:
@@ -315,9 +314,9 @@ def check_coll_inheritance(ctx, coll, mode):
             inheritance = "Enabled" if result[0] == "1" else "Disabled"
 
     if inheritance == "Disabled":
-        ctx.writeLine("stdout", f"OK: Inheritance is {inheritance}. (Collection: {coll})")
+        ctx.writeLine("stdout", f"OK: Inheritance is {inheritance}. (Path: {coll})")
     elif inheritance == "Enabled":
-        ctx.writeLine("stdout", f"WARN: inheritance is {inheritance}, should be Disabled. (Collection: {coll})")
+        ctx.writeLine("stdout", f"WARN: inheritance is {inheritance}, should be Disabled. (Path: {coll})")
 
         if mode == "write":
             ctx.writeLine("stdout", f"\tRunning in {mode} mode, fixing...")
@@ -325,14 +324,14 @@ def check_coll_inheritance(ctx, coll, mode):
             try:
                 ctx.msiSetACL("recursive", "admin:noinherit", "", str(coll))
             except Exception:
-                ctx.writeLine("stdout", "ERROR: Something went wrong while setting inheritance.")
+                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting inheritance. (Path: {coll})")
 
             if ensure_fix(ctx, "inheritance", coll):
-                ctx.writeLine("stdout", f"\tDone.")
+                ctx.writeLine("stdout", "\tDone.")
             else:
-                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting inheritance.")            
+                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting inheritance. (Path: {coll})")
     else:
-        ctx.writeLine("stdout", f"ERROR: Could not retrieve collection's inheritance. (Collection: {coll})")
+        ctx.writeLine("stdout", f"ERROR: Could not retrieve collection's inheritance. (Path: {coll})")
 
 
 def check_acls(ctx, coll, mode):
@@ -424,14 +423,16 @@ def check_metadata(ctx, coll, mode, user):
                                 # Update zone
                                 ctx.msiModAVUMetadata("-C", str(coll), "set", str(attr), str(new_value), "")
                             except Exception:
-                                ctx.writeLine("stdout", "ERROR: Something went wrong while setting AVU.")
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting AVU '{attr}'.")
 
                             if ensure_fix(ctx, "avu", coll, attr=attr, value=new_value):
-                                ctx.writeLine("stdout", f"\tDone.")
+                                ctx.writeLine("stdout", "\tDone.")
                             else:
-                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting AVU.")  
+                                ctx.writeLine("stdout", f"ERROR: Something went wrong while setting AVU '{attr}'.")
                     else:
                         ctx.writeLine("stdout", f"OK: AVU '{attr}' contains zone that matches current zone. (Metadata zone: '{avu_zone}', current zone: '{current_zone}')")
+    else:
+        ctx.writeLine("stdout", "ERROR: Could not retrieve collection's metadata.")
 
 
 def ensure_fix(ctx, op, coll, user_id="", access="", attr="", value=""):
@@ -472,10 +473,10 @@ def ensure_fix(ctx, op, coll, user_id="", access="", attr="", value=""):
             ensured = True
     elif op == "inheritance":
         query = genquery.row_iterator(
-                "COLL_INHERITANCE",
-                f"COLL_NAME like '{coll}'",
-                genquery.AS_LIST,
-                ctx)
+            "COLL_INHERITANCE",
+            f"COLL_NAME like '{coll}'",
+            genquery.AS_LIST,
+            ctx)
 
         if query.total_rows() > 0:
             for result in query:

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -1,0 +1,79 @@
+#!/usr/bin/irule -r irods_rule_engine_plugin-python-instance -F
+#
+# irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/package-check.r '*coll=' '*mode='
+#
+import genquery
+
+# TODO: check that parent folder includes words like "vault"?
+def get_coll_parent(coll, ctx):
+    parent_query = genquery.row_iterator(
+        "COLL_PARENT_NAME",
+        "COLL_NAME like '{}'".format(coll),
+        genquery.AS_LIST,
+        ctx)
+	
+    for parent in parent_query:
+        try: 
+            return parent[0]
+        except Exception:
+            ctx.writeString("queryError", "Error retrieving parent collection of data package {}".format(coll))
+
+def get_coll_access(coll, ctx):
+    ctx.writeLine("stdout", "Retrieving ACLs of data package {}".format(coll)) 
+    access_query = genquery.row_iterator(
+        "COLL_ACCESS_USER_ID, COLL_ACCESS_NAME",
+        "COLL_NAME like '{}'".format(coll),
+        genquery.AS_LIST,
+        ctx) 
+
+    acl = []
+    for (user, access) in access_query:
+        try:
+            user_access = {}		
+
+            user_access['user'] = user
+            user_access['access'] = access
+
+            acl.append(user_access)
+        except Exception:
+            ctx.writeString("queryError", "Error retrieving ACLs of data package {}".format(coll))
+
+    for item in acl:
+        for key, value in item.items():
+            ctx.writeLine("stdout", "{}, {}".format(key, value))    
+
+    return acl
+
+def get_coll_inheritance(coll, ctx):
+    inherit_query = genquery.row_iterator(
+        "COLL_INHERITANCE",
+        "COLL_NAME like '{}'".format(coll),
+        genquery.AS_LIST,
+        ctx)
+	
+    for inherit in inherit_query:
+        try: 
+            return inherit[0]
+        except Exception:
+            ctx.writeString("queryError", "Error retrieving inheritance info of data package {}".format(coll))
+
+def main(rule_args, ctx, rei):
+    coll = global_vars["*coll"]
+    mode = global_vars["*mode"]
+
+    parent_coll = get_coll_parent(coll, ctx)
+
+    coll_acl = get_coll_access(coll, ctx)
+    parent_acl = get_coll_access(parent_coll, ctx)
+
+    coll_inherit = get_coll_inheritance(coll, ctx)
+    parent_inherit = get_coll_inheritance(parent_coll, ctx)
+
+    if (coll_acl == parent_acl):
+        ctx.writeLine("stdout", "Data package ACLs match group ACLs.") # TODO: ensure check makes sense?    
+
+    if (coll_inherit == parent_inherit):
+        ctx.writeLine("stdout", "Data package inheritance matches group inheritance.") # TODO: this check or just "if package is in vault then must be disabled"?
+
+INPUT *coll=, *mode=read
+OUTPUT ruleExecOut

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -170,48 +170,58 @@ def get_data_acls(ctx, coll, data):
 # Compare ACLs
 def compare_acls(ctx, acls, g_acls, path, mode):
     if len(g_acls) > 0 and len(acls) > 0:
-        if (acls == g_acls): # TODO: ensure check makes sense?
-            ctx.writeLine("stdout", "OK: ACLs of current collection/data object match group ACLs. (Path: {})".format(path))
+        if (acls == g_acls):
+            ctx.writeLine("stdout", "OK: ACLs of current collection/data object are correct. (Path: {})".format(path))
         else:
-            ctx.writeLine("stdout", "WARN: ACLs of current collection/data object do not match group ACLs. (Path: {})".format(path))
-
             acls_to_remove = []
             acls_to_add = []
-            for acl in acls + g_acls:
+
+            join_acls = [acl for i, acl in enumerate(acls + g_acls) if acl not in (acls + g_acls)[:i]]
+            for acl in join_acls:
+                user_name = acl['user_name']
+                access = acl['access']
+
                 if acl not in acls:
-                    ctx.writeLine("stdout", "\tUser '{}' has '{}' rights to group collection, but not to this collection/data object.".format(acl['user_name'], acl['access']))
-                    acls_to_add.append(acl)
+                    if access != "own": # Any own rights from group collection can be skipped
+                        acls_to_add.append(acl)
                 elif acl not in g_acls:
-                    ctx.writeLine("stdout", "\tUser '{}' has '{}' rights to this collection/data object, but not to group collection.".format(acl['user_name'], acl['access']))
+                    if user_name != "rods" and (user_name != "anonymous" and access == "read"): # If rods has any rights or anonymous has read rights, they don't have to be removed
+                        acls_to_remove.append(acl)
+                elif user_name in path and access == "own": # If group already has own rights on collection/data package, they should be removed
                     acls_to_remove.append(acl)
 
-            if mode == "write":
-                if len(acls_to_add) > 0:
-                    ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
+            if len(acls_to_add) > 0 or len(acls_to_remove) > 0:
+                ctx.writeLine("stdout", "WARN: ACLs of current collection/data object have issues. (Path: {})".format(path))
 
+                if len(acls_to_add) > 0:
                     for acl in acls_to_add:
                         user_name = acl['user_name']
                         access = acl['access']
 
-                        try:
-                            ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
-                        except Exception:
-                            ctx.writeString("serverLog", "Something went wrong while setting ACL.")
+                        ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to the group collection but not to this collection/data object, and should have those rights.".format(acl['user_name'], acl['access']))                    
+
+                        if mode == "write":
+                            ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
+                            try:
+                                ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
+                            except Exception:
+                                ctx.writeString("serverLog", "Something went wrong while setting ACL.")
 
                 if len(acls_to_remove) > 0:
-                    ctx.writeLine("stdout", "\tRunning in {} mode, removing extra ACLs...".format(mode))
-
                     for acl in acls_to_remove:
                         user_name = acl['user_name']
                         access = acl['access']
-
-                        if user_name == "rods" or user_name == "anonymous":
-                            ctx.writeLine("stdout", "\tUser is '{}', skipping...".format(user_name))
-                        else:
+                        
+                        ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to this collection/data object, but should not have those rights.".format(acl['user_name'], acl['access']))
+                        
+                        if mode == "write":
+                            ctx.writeLine("stdout", "\tRunning in {} mode, removing extra ACLs...".format(mode))
                             try:
                                 ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
                             except Exception:
                                 ctx.writeString("serverLog", "Something went wrong while setting ACL.")
+            else:
+                ctx.writeLine("stdout", "OK: ACLs of current collection/data object are correct. (Path: {})".format(path))
     else:
         ctx.writeLine("stdout", "ERROR: No ACLs found for this collection/data object. (Path: {})".format(path))
 
@@ -316,18 +326,10 @@ def check_metadata(ctx, coll, mode, user):
                         ctx.writeLine("stdout", "WARN: AVU '{}' contains zone that does not match current zone. (AVU zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
 
                         if (mode == "write"):
-                            ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
-                            # ctx.writeLine("stdout", "...Done.")
+                            ctx.writeLine("stdout", "\tRunning in {} mode, fixing...".format(mode))
+                            new_value = value.replace(avu_zone, current_zone)
 
-                    else:
-                        ctx.writeLine("stdout", "OK: AVU '{}' contains zone that matches current zone. (AVU zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
-
-                        # TODO: move this to the other check once done testing
-                        ctx.writeLine("stdout", "Old value: {}".format(value))
-                        if (mode == "write"):
-                            ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
-                            new_value = value.replace(avu_zone, "newZone")
-                            ctx.writeLine("stdout", "New value: {}".format(new_value))
+                            ctx.writeLine("stdout", "attr: {} | new_value: {} | coll: {}".format(str(attr), str(new_value), coll))
 
                             try:
                                 # Set write permissions first to be able to modify AVU
@@ -336,14 +338,16 @@ def check_metadata(ctx, coll, mode, user):
                                 # Update zone
                                 out = ctx.msiString2KeyValPair("{}={}".format(str(attr), str(new_value)), irods_types.KeyValPair())
                                 kvp = out['arguments'][1]
-                                ctx.msiSetKeyValuePairsToObj(kvp, coll, '-C')
+                                ctx.writeLine("stdout", str(type(kvp)))
+                                ctx.msiSetKeyValuePairsToObj(kvp, str(coll), "-C")
 
                                 # Remove write permissions
                                 ctx.msiSetACL("recursive", "null", str(user), str(coll))
 
                             except Exception:
-                                ctx.writeLine("stdout", "Something went wrong while setting AVU.")
-                                # ctx.writeString("serverLog", "Something went wrong while setting AVU.")
+                                ctx.writeLine("stdout", "ERROR: Something went wrong while setting AVU.")
+                    else:
+                        ctx.writeLine("stdout", "OK: AVU '{}' contains zone that matches current zone. (AVU zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
 
 
 def main(rule_args, ctx, rei):
@@ -382,6 +386,7 @@ def main(rule_args, ctx, rei):
 INPUT *coll=, *mode=read
 OUTPUT ruleExecOut
 
+# (DONE) TODO: Add exception to write mode for "own" rights of group
 # TODO: Test another user
 # TODO: Add sanity check (double check ACLs for specific users)
 # TODO: Add sanity check (rerun check after fix)

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -190,6 +190,9 @@ def compare_acls(acls, g_acls, path, mode, ctx):
                     ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
 
                     for acl in acls_to_add:
+                        user_name = acl['user_name']
+                        access = acl['access']
+
                         try:
                             ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
                         except Exception:

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -4,32 +4,54 @@
 #
 import genquery
 
-# TODO: check that parent folder includes words like "vault"?
+
+# Determine existence of collection
+def coll_exists(coll, ctx):
+    try:
+        exists_query = genquery.row_iterator(
+            "COLL_ID",
+            "COLL_NAME like '{}'".format(coll),
+            genquery.AS_LIST,
+            ctx)
+
+        if exists_query.total_rows() > 0:
+            return True
+        else:
+            return False
+
+    except Exception:
+        ctx.writeString("queryError", "Error determining existence of data package {}".format(coll))
+
+
+# Get parent of collection
 def get_coll_parent(coll, ctx):
     parent_query = genquery.row_iterator(
         "COLL_PARENT_NAME",
         "COLL_NAME like '{}'".format(coll),
         genquery.AS_LIST,
         ctx)
-	
-    for parent in parent_query:
-        try: 
-            return parent[0]
+
+    for result in parent_query:
+        try:
+            parent = result[0]
+            if 'vault-' in parent: # TODO: check if path ends in "vault-*"
+                return parent
         except Exception:
             ctx.writeString("queryError", "Error retrieving parent collection of data package {}".format(coll))
 
-def get_coll_access(coll, ctx):
-    ctx.writeLine("stdout", "Retrieving ACLs of data package {}".format(coll)) 
+
+# Get ACLs of collection
+def get_coll_acls(coll, ctx):
     access_query = genquery.row_iterator(
-        "COLL_ACCESS_USER_ID, COLL_ACCESS_NAME",
+        "ORDER(COLL_ACCESS_USER_ID), COLL_ACCESS_NAME",
         "COLL_NAME like '{}'".format(coll),
         genquery.AS_LIST,
-        ctx) 
+        ctx)
 
     acl = []
     for (user, access) in access_query:
         try:
-            user_access = {}		
+            user_access = {}
 
             user_access['user'] = user
             user_access['access'] = access
@@ -38,42 +60,65 @@ def get_coll_access(coll, ctx):
         except Exception:
             ctx.writeString("queryError", "Error retrieving ACLs of data package {}".format(coll))
 
-    for item in acl:
-        for key, value in item.items():
-            ctx.writeLine("stdout", "{}, {}".format(key, value))    
+    # for item in acl:
+    #     for key, value in item.items():
+    #         ctx.writeLine("stdout", "{}, {}".format(key, value))
 
     return acl
 
+
+# Get inheritance of collection
 def get_coll_inheritance(coll, ctx):
     inherit_query = genquery.row_iterator(
         "COLL_INHERITANCE",
         "COLL_NAME like '{}'".format(coll),
         genquery.AS_LIST,
         ctx)
-	
-    for inherit in inherit_query:
-        try: 
-            return inherit[0]
+
+    for result in inherit_query:
+        try:
+            inheritance = "Disabled" if result[0] == "0" else "Enabled"
+            return inheritance
         except Exception:
             ctx.writeString("queryError", "Error retrieving inheritance info of data package {}".format(coll))
+
 
 def main(rule_args, ctx, rei):
     coll = global_vars["*coll"]
     mode = global_vars["*mode"]
 
-    parent_coll = get_coll_parent(coll, ctx)
+    # TODO: check if user running script is rodsadmin
 
-    coll_acl = get_coll_access(coll, ctx)
-    parent_acl = get_coll_access(parent_coll, ctx)
+    if coll_exists(coll, ctx):
+        parent_coll = get_coll_parent(coll, ctx)
 
-    coll_inherit = get_coll_inheritance(coll, ctx)
-    parent_inherit = get_coll_inheritance(parent_coll, ctx)
+        coll_acl = get_coll_acls(coll, ctx)
+        parent_acl = get_coll_acls(parent_coll, ctx)
 
-    if (coll_acl == parent_acl):
-        ctx.writeLine("stdout", "Data package ACLs match group ACLs.") # TODO: ensure check makes sense?    
+        coll_inherit = get_coll_inheritance(coll, ctx)
+        parent_inherit = get_coll_inheritance(parent_coll, ctx)
 
-    if (coll_inherit == parent_inherit):
-        ctx.writeLine("stdout", "Data package inheritance matches group inheritance.") # TODO: this check or just "if package is in vault then must be disabled"?
+        # Check if data packge ACLs match group ACLs
+        if (coll_acl == parent_acl):
+            ctx.writeLine("stdout", "Data package ACLs match group ACLs.") # TODO: ensure check makes sense?
+        else:
+            ctx.writeLine("stdout", "Data package ACLs do NOT match group ACLs.")
+            # TODO: show ACLs that need fixing
+
+            if mode == "write":
+                ctx.writeLine("stdout", "Fixing...")
+
+        # Check if data packge inheritance matches group inheritance            
+        if (coll_inherit == parent_inherit): # TODO: this check or just "if package is in vault then must be disabled"?
+            ctx.writeLine("stdout", "Data package inheritance matches group inheritance.")
+        else:
+            ctx.writeLine("stdout", "Data package inheritance does NOT match group inheritance.")
+            # TODO: show inheritance differences
+
+            if mode == "write":
+                ctx.writeLine("stdout", "Fixing...")                
+    else:
+        ctx.writeLine("stdout", "Collection does not exist, try again.")
 
 INPUT *coll=, *mode=read
 OUTPUT ruleExecOut

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -5,39 +5,86 @@
 import genquery
 
 
+# Get user name from user ID
+def get_user_name(id, ctx):
+    user_query = genquery.row_iterator(
+        "USER_NAME",
+        "USER_ID = '{}'".format(id),
+        genquery.AS_LIST,
+        ctx)
+
+    user_name = ""
+    if user_query.total_rows() > 0:
+        for result in user_query:
+            user_name = result[0]
+    return user_name
+
+
 # Determine existence of collection
 def coll_exists(coll, ctx):
-    try:
-        exists_query = genquery.row_iterator(
-            "COLL_ID",
-            "COLL_NAME like '{}'".format(coll),
-            genquery.AS_LIST,
-            ctx)
-
-        if exists_query.total_rows() > 0:
-            return True
-        else:
-            return False
-
-    except Exception:
-        ctx.writeString("queryError", "Error determining existence of data package {}".format(coll))
-
-
-# Get parent of collection
-def get_coll_parent(coll, ctx):
-    parent_query = genquery.row_iterator(
-        "COLL_PARENT_NAME",
+    exists_query = genquery.row_iterator(
+        "COLL_ID",
         "COLL_NAME like '{}'".format(coll),
         genquery.AS_LIST,
         ctx)
 
-    for result in parent_query:
-        try:
-            parent = result[0]
-            if 'vault-' in parent: # TODO: check if path ends in "vault-*"
-                return parent
-        except Exception:
-            ctx.writeString("queryError", "Error retrieving parent collection of data package {}".format(coll))
+    if exists_query.total_rows() > 0:
+        return True
+    else:
+        return False
+
+
+# Get group collection
+def get_group_coll(coll, ctx):
+    group_coll = ""
+    if coll.rsplit('/', 1)[-1].startswith("vault-"):
+        group_coll = coll
+    else:
+        group_query = genquery.row_iterator(
+            "COLL_PARENT_NAME",
+            "COLL_NAME like '{}'".format(coll),
+            genquery.AS_LIST,
+            ctx)
+
+        if group_query.total_rows() > 0:
+            for result in group_query:
+                if result[0].rsplit('/', 1)[-1].startswith("vault-"):
+                    group_coll = result[0]
+                else:   # If parent collection is not group collection, go up another level
+                    group_coll = get_group_coll(group_coll, ctx)
+    return group_coll
+
+
+# Get collection's subcollections
+def get_subcolls(coll, ctx):
+    subcoll_query = genquery.row_iterator(
+            "COLL_NAME",
+            "COLL_NAME like '{}/%'".format(coll),
+            genquery.AS_LIST,
+            ctx)
+
+    subcolls = []
+    if subcoll_query.total_rows() > 0:
+        for result in subcoll_query:
+            subcolls.append(result[0])
+        
+    return subcolls
+
+
+# Get collection's data objects
+def get_dataobjs(coll, ctx):
+    data_query = genquery.row_iterator(
+        "DATA_NAME",
+        "COLL_NAME like '{}'".format(coll),
+        genquery.AS_LIST,
+        ctx)
+
+    dataobjs = []
+    if data_query.total_rows() > 0:
+        for result in data_query:
+            dataobjs.append(result[0])
+
+    return dataobjs            
 
 
 # Get ACLs of collection
@@ -49,76 +96,205 @@ def get_coll_acls(coll, ctx):
         ctx)
 
     acl = []
-    for (user, access) in access_query:
-        try:
+    if access_query.total_rows() > 0:
+        for (user, access) in access_query:
             user_access = {}
 
-            user_access['user'] = user
-            user_access['access'] = access
+            user_access['user_id'] = user
+            user_access['user_name'] = get_user_name(user, ctx)
+    
+            if access == "read_object":
+                user_access['access'] = "read"
+            elif access == "modify_object":
+                user_access['access'] = "write"
+            else:
+                user_access['access'] = access
+    
 
             acl.append(user_access)
-        except Exception:
-            ctx.writeString("queryError", "Error retrieving ACLs of data package {}".format(coll))
-
-    # for item in acl:
-    #     for key, value in item.items():
-    #         ctx.writeLine("stdout", "{}, {}".format(key, value))
-
+        # for item in acl:
+        #     for key, value in item.items():
+        #         ctx.writeLine("stdout", "{}, {}".format(key, value))
     return acl
 
 
-# Get inheritance of collection
-def get_coll_inheritance(coll, ctx):
+# Get ACLs of data
+def get_data_acls(coll, data, ctx):
+    access_query = genquery.row_iterator(
+        "ORDER(DATA_ACCESS_USER_ID), DATA_ACCESS_NAME",
+        "COLL_NAME like '{}' AND DATA_NAME like '{}'".format(coll, data),
+        genquery.AS_LIST,
+        ctx)
+
+    acl = []
+    if access_query.total_rows() > 0:    
+        for (user, access) in access_query:
+            user_access = {}
+
+            user_access['user_id'] = user
+            user_access['user_name'] = get_user_name(user, ctx)
+
+            if access == "read_object":
+                user_access['access'] = "read"
+            elif access == "modify_object":
+                user_access['access'] = "write"
+            else:
+                user_access['access'] = access
+    
+
+            acl.append(user_access)
+
+        # for item in acl:
+        #     for key, value in item.items():
+        #         ctx.writeLine("stdout", "{}, {}".format(key, value))
+    return acl
+
+
+# Compare ACLs
+def compare_acls(acls, g_acls, path, mode, ctx):
+    if len(g_acls) > 0 and len(acls) > 0:
+        if (acls == g_acls): # TODO: ensure check makes sense?
+            ctx.writeLine("stdout", "OK: ACLs of current collection/data object match group ACLs. (Path: {})".format(path))
+        else:
+            ctx.writeLine("stdout", "WARN: ACLs of current collection/data object do not match group ACLs. (Path: {})".format(path))
+
+            acls_to_remove = []
+            acls_to_add = []            
+            for acl in acls + g_acls:
+                if acl not in acls:
+                    ctx.writeLine("stdout", "\tUser '{}' has '{}' rights to group collection, but not to this collection/data object.".format(acl['user_name'], acl['access']))
+                    acls_to_add.append(acl)
+                elif acl not in g_acls:
+                    ctx.writeLine("stdout", "\tUser '{}' has '{}' rights to this collection/data object, but not to group collection.".format(acl['user_name'], acl['access']))
+                    acls_to_remove.append(acl)
+            
+            if mode == "write":
+                if len(acls_to_add) > 0:
+                    ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
+                    
+                    for acl in acls_to_add:
+                        ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
+                    
+                    ctx.writeLine("stdout", "\t...Done.".format(mode))
+                if len(acls_to_remove) > 0:
+                    ctx.writeLine("stdout", "\tRunning in {} mode, removing extra ACLs...".format(mode))
+                    
+                    for acl in acls_to_remove:
+                        user_name = acl['user_name']
+                        access = acl['access']
+
+                        if user_name == "rods" or user_name == "anonymous":
+                            ctx.writeLine("stdout", "\tUser is '{}', skipping...".format(user_name))
+                        else:                        
+                            ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
+                    
+                    ctx.writeLine("stdout", "\t...Done.".format(mode))                    
+            
+    else:
+        ctx.writeLine("stdout", "ERROR: No ACLs found for this collection/data object. (Path: {})".format(path))
+
+
+# Check inheritance of collection
+def check_coll_inheritance(coll, mode, ctx):
     inherit_query = genquery.row_iterator(
         "COLL_INHERITANCE",
         "COLL_NAME like '{}'".format(coll),
         genquery.AS_LIST,
         ctx)
 
-    for result in inherit_query:
-        try:
+    inheritance = ""
+    if inherit_query.total_rows() > 0:
+        for result in inherit_query:
             inheritance = "Disabled" if result[0] == "0" else "Enabled"
-            return inheritance
-        except Exception:
-            ctx.writeString("queryError", "Error retrieving inheritance info of data package {}".format(coll))
+    
+    if inheritance == "Disabled":
+        ctx.writeLine("stdout", "OK: Inheritance is {}. (Collection: {})".format(inheritance, coll))
+    elif inheritance == "Enabled":
+        ctx.writeLine("stdout", "WARN: inheritance is {}, should be Disabled. (Collection: {})".format(inheritance, coll))
+
+        if mode == "write":
+                ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
+                ctx.msiSetACL("recursive", "admin:noinherit", "", str(coll))
+                ctx.writeLine("stdout", "...Fixed.".format(mode))
+    else:
+        ctx.writeLine("stdout", "ERROR: Error retrieving collection's inheritance. (Collection: {})".format(coll))
+
+
+# Check ACLs
+def check_acls(coll, mode, ctx):
+    # Get group collection
+    group_coll = get_group_coll(coll, ctx)
+
+    if group_coll != "": 
+        # Check ACLs of provided collection
+        group_acls = get_coll_acls(group_coll, ctx)
+        coll_acls = get_coll_acls(coll, ctx)
+        compare_acls(coll_acls, group_acls, coll, mode, ctx)
+
+        # Check ACLs of provided collection's data objects
+        dataobjs = get_dataobjs(coll, ctx)
+
+        if len(dataobjs) > 0:
+            for data_obj in dataobjs:
+                dataobj_acls = get_data_acls(coll, data_obj, ctx)
+                compare_acls(dataobj_acls, group_acls, "{}/{}".format(coll, data_obj), mode, ctx)             
+
+        # Check ACLs of provided collection's subcollections
+        subcolls = get_subcolls(coll, ctx)
+
+        if len(subcolls) > 0:
+            for subcoll in subcolls:
+                subcoll_acls = get_coll_acls(subcoll, ctx)
+                compare_acls(subcoll_acls, group_acls, subcoll, mode, ctx)
+        
+            # Check ACLs of provided collection's subcollections' data objects
+            subcoll_dataobjs = get_dataobjs(subcoll, ctx)
+            
+            if len(subcoll_dataobjs) > 0:
+                for subcoll_dataobj in subcoll_dataobjs:
+                    subcoll_dataobj_acls = get_data_acls(subcoll, subcoll_dataobj, ctx)
+                    compare_acls(subcoll_dataobj_acls, group_acls, "{}/{}".format(subcoll, subcoll_dataobj), mode, ctx)
+    else:
+        ctx.writeLine("stdout", "ERROR: Error retrieving group collection.")          
+
+
+# Check inheritance
+def check_inheritance(coll, mode, ctx):
+    # If space is vault space, then inheritance should be disabled
+    if 'vault-' in coll:
+        # Check inheritance of collection
+        coll_inherit = check_coll_inheritance(coll, mode, ctx)
+
+        # Check inheritance of collection's subcollections
+        subcolls = get_subcolls(coll, ctx)
+
+        if len(subcolls) > 0:
+            for subcoll in subcolls:
+                subcoll_inherit = check_coll_inheritance(subcoll, mode, ctx)
 
 
 def main(rule_args, ctx, rei):
     coll = global_vars["*coll"]
     mode = global_vars["*mode"]
+    logged_user = ctx.uuClientFullNameWrapper("")['arguments'][0]
+    logged_user_type = ctx.uuGetUserType(logged_user, "")['arguments'][1]
 
-    # TODO: check if user running script is rodsadmin
+    if logged_user_type == 'rodsadmin':    
+        if coll_exists(coll,ctx):
+            ctx.writeLine("stdout", "Executing package check rule for collection: {} (mode: {})".format(coll, mode))
+            ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
-    if coll_exists(coll, ctx):
-        parent_coll = get_coll_parent(coll, ctx)
+            # Check if collection ACLs match group ACLs
+            check_acls(coll, mode, ctx)
+            ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
-        coll_acl = get_coll_acls(coll, ctx)
-        parent_acl = get_coll_acls(parent_coll, ctx)
-
-        coll_inherit = get_coll_inheritance(coll, ctx)
-        parent_inherit = get_coll_inheritance(parent_coll, ctx)
-
-        # Check if data packge ACLs match group ACLs
-        if (coll_acl == parent_acl):
-            ctx.writeLine("stdout", "Data package ACLs match group ACLs.") # TODO: ensure check makes sense?
+            # Check collection inheritance        
+            check_inheritance(coll, mode, ctx)
+            ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")            
         else:
-            ctx.writeLine("stdout", "Data package ACLs do NOT match group ACLs.")
-            # TODO: show ACLs that need fixing
-
-            if mode == "write":
-                ctx.writeLine("stdout", "Fixing...")
-
-        # Check if data packge inheritance matches group inheritance            
-        if (coll_inherit == parent_inherit): # TODO: this check or just "if package is in vault then must be disabled"?
-            ctx.writeLine("stdout", "Data package inheritance matches group inheritance.")
-        else:
-            ctx.writeLine("stdout", "Data package inheritance does NOT match group inheritance.")
-            # TODO: show inheritance differences
-
-            if mode == "write":
-                ctx.writeLine("stdout", "Fixing...")                
+            ctx.writeLine("stdout", "ERROR: Collection does not exist, try again.")
     else:
-        ctx.writeLine("stdout", "Collection does not exist, try again.")
+        ctx.writeLine("stdout", "ERROR: This rule can only be run by a rodsadmin user.")    
 
 INPUT *coll=, *mode=read
 OUTPUT ruleExecOut

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -83,7 +83,7 @@ def get_subcolls(coll, ctx):
     if subcoll_query.total_rows() > 0:
         for result in subcoll_query:
             subcolls.append(result[0])
-        
+
     return subcolls
 
 
@@ -100,7 +100,7 @@ def get_dataobjs(coll, ctx):
         for result in data_query:
             dataobjs.append(result[0])
 
-    return dataobjs            
+    return dataobjs
 
 
 # Get ACLs of collection
@@ -118,14 +118,14 @@ def get_coll_acls(coll, ctx):
 
             user_access['user_id'] = user
             user_access['user_name'] = get_user_name(user, ctx)
-    
+
             if access == "read_object":
                 user_access['access'] = "read"
             elif access == "modify_object":
                 user_access['access'] = "write"
             else:
                 user_access['access'] = access
-    
+
 
             acl.append(user_access)
         # for item in acl:
@@ -143,7 +143,7 @@ def get_data_acls(coll, data, ctx):
         ctx)
 
     acl = []
-    if access_query.total_rows() > 0:    
+    if access_query.total_rows() > 0:
         for (user, access) in access_query:
             user_access = {}
 
@@ -156,7 +156,7 @@ def get_data_acls(coll, data, ctx):
                 user_access['access'] = "write"
             else:
                 user_access['access'] = access
-    
+
 
             acl.append(user_access)
 
@@ -175,7 +175,7 @@ def compare_acls(acls, g_acls, path, mode, ctx):
             ctx.writeLine("stdout", "WARN: ACLs of current collection/data object do not match group ACLs. (Path: {})".format(path))
 
             acls_to_remove = []
-            acls_to_add = []            
+            acls_to_add = []
             for acl in acls + g_acls:
                 if acl not in acls:
                     ctx.writeLine("stdout", "\tUser '{}' has '{}' rights to group collection, but not to this collection/data object.".format(acl['user_name'], acl['access']))
@@ -183,31 +183,31 @@ def compare_acls(acls, g_acls, path, mode, ctx):
                 elif acl not in g_acls:
                     ctx.writeLine("stdout", "\tUser '{}' has '{}' rights to this collection/data object, but not to group collection.".format(acl['user_name'], acl['access']))
                     acls_to_remove.append(acl)
-            
+
             if mode == "write":
                 if len(acls_to_add) > 0:
                     ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
-                    
+
                     for acl in acls_to_add:
                         try:
                             ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
                         except Exception:
                             ctx.writeString("serverLog", "Something went wrong while setting ACL.")
-                    
+
                 if len(acls_to_remove) > 0:
                     ctx.writeLine("stdout", "\tRunning in {} mode, removing extra ACLs...".format(mode))
-                    
+
                     for acl in acls_to_remove:
                         user_name = acl['user_name']
                         access = acl['access']
 
                         if user_name == "rods" or user_name == "anonymous":
                             ctx.writeLine("stdout", "\tUser is '{}', skipping...".format(user_name))
-                        else:                        
-                            try: 
+                        else:
+                            try:
                                 ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
                             except Exception:
-                                ctx.writeString("serverLog", "Something went wrong while setting ACL.")                    
+                                ctx.writeString("serverLog", "Something went wrong while setting ACL.")
     else:
         ctx.writeLine("stdout", "ERROR: No ACLs found for this collection/data object. (Path: {})".format(path))
 
@@ -223,8 +223,8 @@ def check_coll_inheritance(coll, mode, ctx):
     inheritance = ""
     if inherit_query.total_rows() > 0:
         for result in inherit_query:
-            inheritance = "Disabled" if result[0] == "0" else "Enabled"
-    
+            inheritance = "Enabled" if result[0] == "1" else "Disabled"
+
     if inheritance == "Disabled":
         ctx.writeLine("stdout", "OK: Inheritance is {}. (Collection: {})".format(inheritance, coll))
     elif inheritance == "Enabled":
@@ -246,7 +246,7 @@ def check_acls(coll, mode, ctx):
     # Get group collection
     group_coll = get_group_coll(coll, ctx)
 
-    if group_coll != "": 
+    if group_coll != "":
         # Check ACLs of provided collection
         group_acls = get_coll_acls(group_coll, ctx)
         coll_acls = get_coll_acls(coll, ctx)
@@ -258,7 +258,7 @@ def check_acls(coll, mode, ctx):
         if len(dataobjs) > 0:
             for data_obj in dataobjs:
                 dataobj_acls = get_data_acls(coll, data_obj, ctx)
-                compare_acls(dataobj_acls, group_acls, "{}/{}".format(coll, data_obj), mode, ctx)             
+                compare_acls(dataobj_acls, group_acls, "{}/{}".format(coll, data_obj), mode, ctx)
 
         # Check ACLs of provided collection's subcollections
         subcolls = get_subcolls(coll, ctx)
@@ -267,16 +267,16 @@ def check_acls(coll, mode, ctx):
             for subcoll in subcolls:
                 subcoll_acls = get_coll_acls(subcoll, ctx)
                 compare_acls(subcoll_acls, group_acls, subcoll, mode, ctx)
-        
+
             # Check ACLs of provided collection's subcollections' data objects
             subcoll_dataobjs = get_dataobjs(subcoll, ctx)
-            
+
             if len(subcoll_dataobjs) > 0:
                 for subcoll_dataobj in subcoll_dataobjs:
                     subcoll_dataobj_acls = get_data_acls(subcoll, subcoll_dataobj, ctx)
                     compare_acls(subcoll_dataobj_acls, group_acls, "{}/{}".format(subcoll, subcoll_dataobj), mode, ctx)
     else:
-        ctx.writeLine("stdout", "ERROR: Could not retrieve group collection.")          
+        ctx.writeLine("stdout", "ERROR: Could not retrieve group collection.")
 
 
 # Check inheritance
@@ -333,9 +333,9 @@ def check_metadata(coll, mode, user, ctx):
                                 out = ctx.msiString2KeyValPair("{}={}".format(str(attr), str(new_value)), 0)
                                 kvp = out['arguments'][1]
                                 ctx.msiSetKeyValuePairsToObj(kvp, coll, '-C')
-                                
+
                                 # Remove write permissions
-                                ctx.msiSetACL("recursive", "null", str(user), str(coll))                        
+                                ctx.msiSetACL("recursive", "null", str(user), str(coll))
 
                             except Exception:
                                 ctx.writeLine("stdout", "Something went wrong while setting AVU.")
@@ -345,14 +345,14 @@ def check_metadata(coll, mode, user, ctx):
 def main(rule_args, ctx, rei):
     coll = global_vars["*coll"]
     mode = global_vars["*mode"]
-    
+
     try:
         current_user = ctx.uuClientFullNameWrapper("")['arguments'][0]
         current_user_type = ctx.uuGetUserType(current_user, "")['arguments'][1]
     except Exception:
         ctx.writeString("serverLog", "Something went wrong while retrieving user information.")
 
-    if current_user_type == 'rodsadmin':    
+    if current_user_type == 'rodsadmin':
         if coll_exists(coll,ctx):
             if 'vault-' in coll:
                 ctx.writeLine("stdout", "Executing package check rule for collection: {} (mode: {})".format(coll, mode))
@@ -362,18 +362,18 @@ def main(rule_args, ctx, rei):
                 check_acls(coll, mode, ctx)
                 ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
-                # Check collection inheritance        
+                # Check collection inheritance
                 check_inheritance(coll, mode, ctx)
                 ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
                 # Update metadata
-                check_metadata(coll, mode, current_user, ctx)            
+                check_metadata(coll, mode, current_user, ctx)
             else:
                 ctx.writeLine("stdout", "ERROR: This rule should be run on vault collections only.")
         else:
             ctx.writeLine("stdout", "ERROR: Collection does not exist, try again.")
     else:
-        ctx.writeLine("stdout", "ERROR: This rule can only be run by a rodsadmin user.")    
+        ctx.writeLine("stdout", "ERROR: This rule can only be run by a rodsadmin user.")
 
 INPUT *coll=, *mode=read
 OUTPUT ruleExecOut

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -3,6 +3,21 @@
 # irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/package-check.r '*coll=' '*mode='
 #
 import genquery
+import os
+
+
+# Determine existence of collection
+def coll_exists(coll, ctx):
+    exists_query = genquery.row_iterator(
+        "COLL_ID",
+        "COLL_NAME like '{}'".format(coll),
+        genquery.AS_LIST,
+        ctx)
+
+    if exists_query.total_rows() > 0:
+        return True
+    else:
+        return False
 
 
 # Get user name from user ID
@@ -18,20 +33,6 @@ def get_user_name(id, ctx):
         for result in user_query:
             user_name = result[0]
     return user_name
-
-
-# Determine existence of collection
-def coll_exists(coll, ctx):
-    exists_query = genquery.row_iterator(
-        "COLL_ID",
-        "COLL_NAME like '{}'".format(coll),
-        genquery.AS_LIST,
-        ctx)
-
-    if exists_query.total_rows() > 0:
-        return True
-    else:
-        return False
 
 
 # Get group collection
@@ -53,6 +54,21 @@ def get_group_coll(coll, ctx):
                 else:   # If parent collection is not group collection, go up another level
                     group_coll = get_group_coll(group_coll, ctx)
     return group_coll
+
+
+# Get AVUs from collection
+def get_avus(coll, avu, ctx):
+    avu_query = genquery.row_iterator(
+        "ORDER(META_COLL_ATTR_NAME), META_COLL_ATTR_VALUE",
+        "META_COLL_ATTR_NAME like '{}' AND COLL_NAME = '{}'".format(avu, coll),
+        genquery.AS_LIST,
+        ctx)
+
+    avus = {}
+    if avu_query.total_rows() > 0:
+        for (attribute, value) in avu_query:
+            avus[attribute] = value
+    return avus
 
 
 # Get collection's subcollections
@@ -173,9 +189,11 @@ def compare_acls(acls, g_acls, path, mode, ctx):
                     ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
                     
                     for acl in acls_to_add:
-                        ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
+                        try:
+                            ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
+                        except Exception:
+                            ctx.writeString("serverLog", "Something went wrong while setting ACL.")
                     
-                    ctx.writeLine("stdout", "\t...Done.".format(mode))
                 if len(acls_to_remove) > 0:
                     ctx.writeLine("stdout", "\tRunning in {} mode, removing extra ACLs...".format(mode))
                     
@@ -186,10 +204,10 @@ def compare_acls(acls, g_acls, path, mode, ctx):
                         if user_name == "rods" or user_name == "anonymous":
                             ctx.writeLine("stdout", "\tUser is '{}', skipping...".format(user_name))
                         else:                        
-                            ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
-                    
-                    ctx.writeLine("stdout", "\t...Done.".format(mode))                    
-            
+                            try: 
+                                ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
+                            except Exception:
+                                ctx.writeString("serverLog", "Something went wrong while setting ACL.")                    
     else:
         ctx.writeLine("stdout", "ERROR: No ACLs found for this collection/data object. (Path: {})".format(path))
 
@@ -213,11 +231,14 @@ def check_coll_inheritance(coll, mode, ctx):
         ctx.writeLine("stdout", "WARN: inheritance is {}, should be Disabled. (Collection: {})".format(inheritance, coll))
 
         if mode == "write":
-                ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
+            ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
+
+            try:
                 ctx.msiSetACL("recursive", "admin:noinherit", "", str(coll))
-                ctx.writeLine("stdout", "...Fixed.".format(mode))
+            except Exception:
+                ctx.writeString("serverLog", "Something went wrong while setting inheritance.")
     else:
-        ctx.writeLine("stdout", "ERROR: Error retrieving collection's inheritance. (Collection: {})".format(coll))
+        ctx.writeLine("stdout", "ERROR: Could not retrieve collection's inheritance. (Collection: {})".format(coll))
 
 
 # Check ACLs
@@ -255,42 +276,100 @@ def check_acls(coll, mode, ctx):
                     subcoll_dataobj_acls = get_data_acls(subcoll, subcoll_dataobj, ctx)
                     compare_acls(subcoll_dataobj_acls, group_acls, "{}/{}".format(subcoll, subcoll_dataobj), mode, ctx)
     else:
-        ctx.writeLine("stdout", "ERROR: Error retrieving group collection.")          
+        ctx.writeLine("stdout", "ERROR: Could not retrieve group collection.")          
 
 
 # Check inheritance
 def check_inheritance(coll, mode, ctx):
-    # If space is vault space, then inheritance should be disabled
-    if 'vault-' in coll:
-        # Check inheritance of collection
-        coll_inherit = check_coll_inheritance(coll, mode, ctx)
+    # Inheritance should be disabled on vault packages
+    # Check inheritance of collection
+    coll_inherit = check_coll_inheritance(coll, mode, ctx)
 
-        # Check inheritance of collection's subcollections
-        subcolls = get_subcolls(coll, ctx)
+    # Check inheritance of collection's subcollections
+    subcolls = get_subcolls(coll, ctx)
 
-        if len(subcolls) > 0:
-            for subcoll in subcolls:
-                subcoll_inherit = check_coll_inheritance(subcoll, mode, ctx)
+    if len(subcolls) > 0:
+        for subcoll in subcolls:
+            subcoll_inherit = check_coll_inheritance(subcoll, mode, ctx)
+
+
+def check_metadata(coll, mode, user, ctx):
+    # if vault status "PUBLISHED" or "DEPUBLISHED"
+        # if AVU refers to Yoda collection, update zone name
+        # if DOI record exists at DataCite, update URL
+        # call update-publications.r on package
+
+    coll_avus = get_avus(coll, "org_%", ctx)
+
+    if bool(coll_avus):
+        vault_status = coll_avus['org_vault_status']
+        if vault_status == "PUBLISHED" or vault_status == "DEPUBLISHED":
+            for (attr, value) in coll_avus.items():
+                if os.path.isabs(value):
+                    current_zone = ctx.uuClientZone("")['arguments'][0]
+                    avu_zone = value.split('/')[1]
+                    if avu_zone != current_zone:
+                        ctx.writeLine("stdout", "WARN: AVU '{}' contains zone that does not match current zone. (AVU zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
+
+                        if (mode == "write"):
+                            ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
+                            # ctx.writeLine("stdout", "...Done.")
+
+                    else:
+                        ctx.writeLine("stdout", "OK: AVU '{}' contains zone that matches current zone. (AVU zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
+
+                        # TODO: move this to the other check once done testing
+                        ctx.writeLine("stdout", "Old value: {}".format(value))
+                        if (mode == "write"):
+                            ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
+                            new_value = value.replace(avu_zone, "newZone")
+                            ctx.writeLine("stdout", "New value: {}".format(new_value))
+
+                            try:
+                                # Set write permissions first to be able to modify AVU
+                                ctx.msiSetACL("recursive", "admin:write", str(user), str(coll))
+
+                                # Update zone
+                                out = ctx.msiString2KeyValPair("{}={}".format(str(attr), str(new_value)), 0)
+                                kvp = out['arguments'][1]
+                                ctx.msiSetKeyValuePairsToObj(kvp, coll, '-C')
+                                
+                                # Remove write permissions
+                                ctx.msiSetACL("recursive", "null", str(user), str(coll))                        
+
+                            except Exception:
+                                ctx.writeLine("stdout", "Something went wrong while setting AVU.")
+                                # ctx.writeString("serverLog", "Something went wrong while setting AVU.")
 
 
 def main(rule_args, ctx, rei):
     coll = global_vars["*coll"]
     mode = global_vars["*mode"]
-    logged_user = ctx.uuClientFullNameWrapper("")['arguments'][0]
-    logged_user_type = ctx.uuGetUserType(logged_user, "")['arguments'][1]
+    
+    try:
+        current_user = ctx.uuClientFullNameWrapper("")['arguments'][0]
+        current_user_type = ctx.uuGetUserType(current_user, "")['arguments'][1]
+    except Exception:
+        ctx.writeString("serverLog", "Something went wrong while retrieving user information.")
 
-    if logged_user_type == 'rodsadmin':    
+    if current_user_type == 'rodsadmin':    
         if coll_exists(coll,ctx):
-            ctx.writeLine("stdout", "Executing package check rule for collection: {} (mode: {})".format(coll, mode))
-            ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
+            if 'vault-' in coll:
+                ctx.writeLine("stdout", "Executing package check rule for collection: {} (mode: {})".format(coll, mode))
+                ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
-            # Check if collection ACLs match group ACLs
-            check_acls(coll, mode, ctx)
-            ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
+                # Check if collection ACLs match group ACLs
+                check_acls(coll, mode, ctx)
+                ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
-            # Check collection inheritance        
-            check_inheritance(coll, mode, ctx)
-            ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")            
+                # Check collection inheritance        
+                check_inheritance(coll, mode, ctx)
+                ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
+
+                # Update metadata
+                check_metadata(coll, mode, current_user, ctx)            
+            else:
+                ctx.writeLine("stdout", "ERROR: This rule should be run on vault collections only.")
         else:
             ctx.writeLine("stdout", "ERROR: Collection does not exist, try again.")
     else:
@@ -298,3 +377,11 @@ def main(rule_args, ctx, rei):
 
 INPUT *coll=, *mode=read
 OUTPUT ruleExecOut
+
+# TODO: Test another user
+# TODO: Add sanity check (double check ACLs for specific users)
+# TODO: Add sanity check (rerun check after fix)
+# (DONE) TODO: Add a check so that it only runs on vault packages
+# TODO: Reorder arguments so that ctx is always the first argument (similar to the ruleset), except for main
+# TODO: Use the same docstyle (Sphinx) for function comments
+# TODO: Run flake8 / ruff on the script for linting

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -1,9 +1,14 @@
 #!/usr/bin/irule -r irods_rule_engine_plugin-python-instance -F
 #
-# irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/package-check.r '*coll=' '*mode='
+# Checks data package for incorrect ACLs and/or AVUs after migration.
+#
+# Usage: 
+# $ irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/package-check.r '*coll=/example/package' '*mode=read/write'
+#
+# *coll: path of the collection to be checked
+# *mode: read (report only), write (report and fix)
 #
 import genquery
-import irods_types
 import os
 
 
@@ -54,7 +59,7 @@ def get_group_coll(ctx, coll):
     :param ctx: Combined type of a callback and rei struct
     :param coll: Collection to determine group of
 
-    :returns: Name of the group of the collection
+    :returns: Name of the group of the collection, empty string if not found
     """
     group_coll = ""
     if coll.rsplit('/', 1)[-1].startswith("vault-"):
@@ -82,7 +87,7 @@ def get_avus(ctx, coll, avu):
     :param coll: Collection to retrieve AVUs from
     :param avu:  Attribute to filter AVUs
 
-    :returns: Dictionary of AVUs for the specified collection.
+    :returns: Dictionary of AVUs for the specified collection, empty dictionary if none found
     """
     avu_query = genquery.row_iterator(
         "ORDER(META_COLL_ATTR_NAME), META_COLL_ATTR_VALUE",
@@ -103,7 +108,7 @@ def get_subcolls(ctx, coll):
     :param ctx:  Combined type of a callback and rei struct
     :param coll: Collection to retrieve subcollections from
 
-    :returns: List of subcollection names
+    :returns: List of subcollection names, empty list if none found
     """
     subcoll_query = genquery.row_iterator(
             "COLL_NAME",
@@ -125,7 +130,7 @@ def get_dataobjs(ctx, coll):
     :param ctx:  Combined type of a callback and rei struct
     :param coll: Collection to retrieve data objects from
 
-    :returns: List of data object names
+    :returns: List of data object names, empty list if none found
     """
     data_query = genquery.row_iterator(
         "DATA_NAME",
@@ -147,7 +152,7 @@ def get_coll_acls(ctx, coll):
     :param ctx:  Combined type of a callback and rei struct
     :param coll: Collection to retrieve ACLs from
 
-    :returns: List of user access details for the collection
+    :returns: List of user access details for the collection, empty list if none found
     """
     access_query = genquery.row_iterator(
         "ORDER(COLL_ACCESS_USER_ID), COLL_ACCESS_NAME",
@@ -185,7 +190,7 @@ def get_data_acls(ctx, coll, data):
     :param coll: Collection containing the data object
     :param data: Name of the data object to retrieve ACLs for
 
-    :returns: List of user access details for the data object
+    :returns: List of user access details for the data object, empty list if none found
     """
     access_query = genquery.row_iterator(
         "ORDER(DATA_ACCESS_USER_ID), DATA_ACCESS_NAME",
@@ -367,7 +372,6 @@ def check_inheritance(ctx, coll, mode):
     :param coll: Collection to check inheritance for
     :param mode: Mode of operation (read or write)
     """
-    # Inheritance should be disabled on vault packages
     # Check inheritance of collection
     coll_inherit = check_coll_inheritance(ctx, coll, mode)
 
@@ -387,46 +391,29 @@ def check_metadata(ctx, coll, mode, user):
     :param mode: Mode of operation (read or write)
     :param user: User performing the operation
     """
-    # if vault status "PUBLISHED" or "DEPUBLISHED"
-        # if AVU refers to Yoda collection, update zone name
-        # if DOI record exists at DataCite, update URL
-        # call update-publications.r on package
-
     coll_avus = get_avus(ctx, coll, "org_%")
 
     if bool(coll_avus):
         vault_status = coll_avus['org_vault_status']
         if vault_status == "PUBLISHED" or vault_status == "DEPUBLISHED":
             for (attr, value) in coll_avus.items():
-                if os.path.isabs(value):
+                if os.path.isabs(value): # Filter AVUs that refer to a path
                     current_zone = ctx.uuClientZone("")['arguments'][0]
                     avu_zone = value.split('/')[1]
                     if avu_zone != current_zone:
-                        ctx.writeLine("stdout", "WARN: AVU '{}' contains zone that does not match current zone. (AVU zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
+                        ctx.writeLine("stdout", "WARN: AVU '{}' contains zone that does not match current zone. (Metadata zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
 
                         if (mode == "write"):
                             ctx.writeLine("stdout", "\tRunning in {} mode, fixing...".format(mode))
                             new_value = value.replace(avu_zone, current_zone)
 
-                            ctx.writeLine("stdout", "attr: {} | new_value: {} | coll: {}".format(str(attr), str(new_value), coll))
-
                             try:
-                                # Set write permissions first to be able to modify AVU
-                                ctx.msiSetACL("recursive", "admin:write", str(user), str(coll))
-
                                 # Update zone
-                                out = ctx.msiString2KeyValPair("{}={}".format(str(attr), str(new_value)), irods_types.KeyValPair())
-                                kvp = out['arguments'][1]
-                                ctx.writeLine("stdout", str(type(kvp)))
-                                ctx.msiSetKeyValuePairsToObj(kvp, str(coll), "-C")
-
-                                # Remove write permissions
-                                ctx.msiSetACL("recursive", "null", str(user), str(coll))
-
+                                ctx.msiModAVUMetadata("-C", str(coll), "set", str(attr), str(new_value), "")
                             except Exception:
                                 ctx.writeLine("stdout", "ERROR: Something went wrong while setting AVU.")
                     else:
-                        ctx.writeLine("stdout", "OK: AVU '{}' contains zone that matches current zone. (AVU zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
+                        ctx.writeLine("stdout", "OK: AVU '{}' contains zone that matches current zone. (Metadata zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
 
 
 def main(rule_args, ctx, rei):
@@ -461,6 +448,7 @@ def main(rule_args, ctx, rei):
 
                 # Update metadata
                 check_metadata(ctx, coll, mode, current_user)
+                ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
             else:
                 ctx.writeLine("stdout", "ERROR: This rule should be run on vault collections only.")
         else:

--- a/tools/package-check.r
+++ b/tools/package-check.r
@@ -23,7 +23,7 @@ def coll_exists(ctx, coll):
     """
     exists_query = genquery.row_iterator(
         "COLL_ID",
-        "COLL_NAME like '{}'".format(coll),
+        f"COLL_NAME like '{coll}'",
         genquery.AS_LIST,
         ctx)
 
@@ -43,7 +43,7 @@ def get_user_name(ctx, id):
     """
     user_query = genquery.row_iterator(
         "USER_NAME",
-        "USER_ID = '{}'".format(id),
+        f"USER_ID = '{id}'",
         genquery.AS_LIST,
         ctx)
 
@@ -68,7 +68,7 @@ def get_group_coll(ctx, coll):
     else:
         group_query = genquery.row_iterator(
             "COLL_PARENT_NAME",
-            "COLL_NAME like '{}'".format(coll),
+            f"COLL_NAME like '{coll}'",
             genquery.AS_LIST,
             ctx)
 
@@ -78,6 +78,7 @@ def get_group_coll(ctx, coll):
                     group_coll = result[0]
                 else:   # If parent collection is not group collection, go up another level
                     group_coll = get_group_coll(ctx, group_coll)
+
     return group_coll
 
 
@@ -92,7 +93,7 @@ def get_avus(ctx, coll, avu):
     """
     avu_query = genquery.row_iterator(
         "ORDER(META_COLL_ATTR_NAME), META_COLL_ATTR_VALUE",
-        "META_COLL_ATTR_NAME like '{}' AND COLL_NAME = '{}'".format(avu, coll),
+        f"META_COLL_ATTR_NAME like '{avu}' AND COLL_NAME = '{coll}'",
         genquery.AS_LIST,
         ctx)
 
@@ -113,7 +114,7 @@ def get_subcolls(ctx, coll):
     """
     subcoll_query = genquery.row_iterator(
         "COLL_NAME",
-        "COLL_NAME like '{}/%'".format(coll),
+        f"COLL_NAME like '{coll}/%'",
         genquery.AS_LIST,
         ctx)
 
@@ -135,7 +136,7 @@ def get_dataobjs(ctx, coll):
     """
     data_query = genquery.row_iterator(
         "DATA_NAME",
-        "COLL_NAME like '{}'".format(coll),
+        f"COLL_NAME like '{coll}'",
         genquery.AS_LIST,
         ctx)
 
@@ -157,7 +158,7 @@ def get_coll_acls(ctx, coll):
     """
     access_query = genquery.row_iterator(
         "ORDER(COLL_ACCESS_USER_ID), COLL_ACCESS_NAME",
-        "COLL_NAME like '{}'".format(coll),
+        f"COLL_NAME like '{coll}'",
         genquery.AS_LIST,
         ctx)
 
@@ -177,9 +178,7 @@ def get_coll_acls(ctx, coll):
                 user_access['access'] = access
 
             acl.append(user_access)
-        # for item in acl:
-        #     for key, value in item.items():
-        #         ctx.writeLine("stdout", "{}, {}".format(key, value))
+
     return acl
 
 
@@ -194,7 +193,7 @@ def get_data_acls(ctx, coll, data):
     """
     access_query = genquery.row_iterator(
         "ORDER(DATA_ACCESS_USER_ID), DATA_ACCESS_NAME",
-        "COLL_NAME like '{}' AND DATA_NAME like '{}'".format(coll, data),
+        f"COLL_NAME like '{coll}' AND DATA_NAME like '{data}'",
         genquery.AS_LIST,
         ctx)
 
@@ -215,9 +214,6 @@ def get_data_acls(ctx, coll, data):
 
             acl.append(user_access)
 
-        # for item in acl:
-        #     for key, value in item.items():
-        #         ctx.writeLine("stdout", "{}, {}".format(key, value))
     return acl
 
 
@@ -232,7 +228,7 @@ def compare_acls(ctx, acls, g_acls, path, mode):
     """
     if len(g_acls) > 0 and len(acls) > 0:
         if (acls == g_acls):
-            ctx.writeLine("stdout", "OK: ACLs of current collection/data object are correct. (Path: {})".format(path))
+            ctx.writeLine("stdout", f"OK: ACLs of current collection/data object are correct. (Path: {path})")
         else:
             acls_to_remove = []
             acls_to_add = []
@@ -252,7 +248,7 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                     acls_to_remove.append(acl)
 
             if len(acls_to_add) > 0 or len(acls_to_remove) > 0:
-                ctx.writeLine("stdout", "WARN: ACLs of current collection/data object have issues. (Path: {})".format(path))
+                ctx.writeLine("stdout", f"WARN: ACLs of current collection/data object have issues. (Path: {path})")
 
                 if len(acls_to_add) > 0:
                     for acl in acls_to_add:
@@ -262,7 +258,7 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                         ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to the group collection but not to this collection/data object, and should have those rights.".format(acl['user_name'], acl['access']))
 
                         if mode == "write":
-                            ctx.writeLine("stdout", "\tRunning in {} mode, adding missing ACLs...".format(mode))
+                            ctx.writeLine("stdout", f"\tRunning in {mode} mode, adding missing ACLs...")
                             try:
                                 ctx.msiSetACL("default", "admin:" + str(access), str(user_name), str(path))
                             except Exception:
@@ -276,15 +272,15 @@ def compare_acls(ctx, acls, g_acls, path, mode):
                         ctx.writeLine("stdout", "\tUser/group '{}' has '{}' rights to this collection/data object, but should not have those rights.".format(acl['user_name'], acl['access']))
 
                         if mode == "write":
-                            ctx.writeLine("stdout", "\tRunning in {} mode, removing extra ACLs...".format(mode))
+                            ctx.writeLine("stdout", f"\tRunning in {mode} mode, removing extra ACLs...")
                             try:
                                 ctx.msiSetACL("default", "null", str(acl['user_name']), str(path))
                             except Exception:
                                 ctx.writeString("serverLog", "Something went wrong while setting ACL.")
             else:
-                ctx.writeLine("stdout", "OK: ACLs of current collection/data object are correct. (Path: {})".format(path))
+                ctx.writeLine("stdout", f"OK: ACLs of current collection/data object are correct. (Path: {path})")
     else:
-        ctx.writeLine("stdout", "ERROR: No ACLs found for this collection/data object. (Path: {})".format(path))
+        ctx.writeLine("stdout", f"ERROR: No ACLs found for this collection/data object. (Path: {path})")
 
 
 def check_coll_inheritance(ctx, coll, mode):
@@ -296,7 +292,7 @@ def check_coll_inheritance(ctx, coll, mode):
     """
     inherit_query = genquery.row_iterator(
         "COLL_INHERITANCE",
-        "COLL_NAME like '{}'".format(coll),
+        f"COLL_NAME like '{coll}'",
         genquery.AS_LIST,
         ctx)
 
@@ -306,19 +302,19 @@ def check_coll_inheritance(ctx, coll, mode):
             inheritance = "Enabled" if result[0] == "1" else "Disabled"
 
     if inheritance == "Disabled":
-        ctx.writeLine("stdout", "OK: Inheritance is {}. (Collection: {})".format(inheritance, coll))
+        ctx.writeLine("stdout", f"OK: Inheritance is {inheritance}. (Collection: {coll})")
     elif inheritance == "Enabled":
-        ctx.writeLine("stdout", "WARN: inheritance is {}, should be Disabled. (Collection: {})".format(inheritance, coll))
+        ctx.writeLine("stdout", f"WARN: inheritance is {inheritance}, should be Disabled. (Collection: {coll})")
 
         if mode == "write":
-            ctx.writeLine("stdout", "Running in {} mode, fixing...".format(mode))
+            ctx.writeLine("stdout", f"Running in {mode} mode, fixing...")
 
             try:
                 ctx.msiSetACL("recursive", "admin:noinherit", "", str(coll))
             except Exception:
                 ctx.writeString("serverLog", "Something went wrong while setting inheritance.")
     else:
-        ctx.writeLine("stdout", "ERROR: Could not retrieve collection's inheritance. (Collection: {})".format(coll))
+        ctx.writeLine("stdout", f"ERROR: Could not retrieve collection's inheritance. (Collection: {coll})")
 
 
 def check_acls(ctx, coll, mode):
@@ -343,7 +339,7 @@ def check_acls(ctx, coll, mode):
         if len(dataobjs) > 0:
             for data_obj in dataobjs:
                 dataobj_acls = get_data_acls(ctx, coll, data_obj)
-                compare_acls(ctx, dataobj_acls, group_acls, "{}/{}".format(coll, data_obj), mode)
+                compare_acls(ctx, dataobj_acls, group_acls, f"{coll}/{data_obj}", mode)
 
         # Check ACLs of provided collection's subcollections
         subcolls = get_subcolls(ctx, coll)
@@ -359,7 +355,7 @@ def check_acls(ctx, coll, mode):
             if len(subcoll_dataobjs) > 0:
                 for subcoll_dataobj in subcoll_dataobjs:
                     subcoll_dataobj_acls = get_data_acls(ctx, subcoll, subcoll_dataobj)
-                    compare_acls(ctx, subcoll_dataobj_acls, group_acls, "{}/{}".format(subcoll, subcoll_dataobj), mode)
+                    compare_acls(ctx, subcoll_dataobj_acls, group_acls, f"{subcoll}/{subcoll_dataobj}", mode)
     else:
         ctx.writeLine("stdout", "ERROR: Could not retrieve group collection.")
 
@@ -400,10 +396,10 @@ def check_metadata(ctx, coll, mode, user):
                     current_zone = ctx.uuClientZone("")['arguments'][0]
                     avu_zone = value.split('/')[1]
                     if avu_zone != current_zone:
-                        ctx.writeLine("stdout", "WARN: AVU '{}' contains zone that does not match current zone. (Metadata zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
+                        ctx.writeLine("stdout", f"WARN: AVU '{attr}' contains zone that does not match current zone. (Metadata zone: '{avu_zone}', current zone: '{current_zone}')")
 
                         if (mode == "write"):
-                            ctx.writeLine("stdout", "\tRunning in {} mode, fixing...".format(mode))
+                            ctx.writeLine("stdout", f"\tRunning in {mode} mode, fixing...")
                             new_value = value.replace(avu_zone, current_zone)
 
                             try:
@@ -412,7 +408,7 @@ def check_metadata(ctx, coll, mode, user):
                             except Exception:
                                 ctx.writeLine("stdout", "ERROR: Something went wrong while setting AVU.")
                     else:
-                        ctx.writeLine("stdout", "OK: AVU '{}' contains zone that matches current zone. (Metadata zone: '{}', current zone: '{}')".format(attr, avu_zone, current_zone))
+                        ctx.writeLine("stdout", f"OK: AVU '{attr}' contains zone that matches current zone. (Metadata zone: '{avu_zone}', current zone: '{current_zone}')")
 
 
 def main(rule_args, ctx, rei):
@@ -434,7 +430,7 @@ def main(rule_args, ctx, rei):
     if current_user_type == 'rodsadmin':
         if coll_exists(ctx, coll):
             if 'vault-' in coll:
-                ctx.writeLine("stdout", "Executing package check rule for collection: {} (mode: {})".format(coll, mode))
+                ctx.writeLine("stdout", f"Executing package check rule for collection: {coll} (mode: {mode})")
                 ctx.writeLine("stdout", "----------------------------------------------------------------------------------------------------")
 
                 # Check if collection ACLs match group ACLs


### PR DESCRIPTION
This PR adds a new script that checks a data package ACL, inheritance, and metadata after migration. Needs to be tested thoroughly before usage on production.