### PR TITLE
YDA-6524: skip unsupported packages in pub.update

### DIFF
--- a/publication.py
+++ b/publication.py
@@ -1535,6 +1535,29 @@ def update_publication(ctx: rule.Context,
         log.write(ctx, "update_publication: Not processing vault package, because initial status is " + status)
         return status
 
+    # Abort if data packages has a known unsupported metadata schema
+    try:
+        metadata_schema = vault.get_current_metadata_schema_data_package(ctx, vault_package)
+    except ValueError as e:
+        log.write(ctx, "update_publication: Not processing vault package, because its metadata schema cannot be determined: " + str(e))
+        publication_state["status"] = "Unrecoverable"
+
+    save_publication_state(ctx, vault_package, publication_state)
+    if _check_return_if_publication_status(["Unrecoverable", "Retry"], "after retrieving metadata schema"):
+        return publication_state["status"]
+
+    if metadata_schema is None:
+        log.write(ctx, "update_publication: Not processing vault package, because it has no metadata schema.")
+        publication_state["status"] = "Unrecoverable"
+    elif schema_utils.is_unsupported_schema(metadata_schema):
+        log.write(ctx,
+                  f"update_publication: Not processing vault package, because it has an unsupported metadata schema: {metadata_schema}")
+        publication_state["status"] = "Unrecoverable"
+
+    save_publication_state(ctx, vault_package, publication_state)
+    if _check_return_if_publication_status(["Unrecoverable", "Retry"], "after checking metadata schema"):
+        return publication_state["status"]
+
     update_base_doi = False
     if "baseDOI" in publication_state:
         if verbose:

--- a/unit-tests/test_util_schema_utils.py
+++ b/unit-tests/test_util_schema_utils.py
@@ -1,0 +1,22 @@
+"""Unit tests for the schema utils module"""
+
+__copyright__ = 'Copyright (c) 2025, Utrecht University'
+__license__   = 'GPLv3, see LICENSE'
+
+import sys
+from unittest import TestCase
+
+sys.path.append('../util')
+
+from schema_utils import is_unsupported_schema
+
+
+class SchemaUtilsTest(TestCase):
+
+    def test_is_unsupported_schema(self):
+        # Known unsupported schema
+        self.assertEqual(is_unsupported_schema("https://yoda.uu.nl/schemas/default-0/metadata.json"), True)
+        # No schema is unsupported as well
+        self.assertEqual(is_unsupported_schema(None), True)
+        # Schemas that we don't know are not marked as (known to be) unsupported
+        self.assertEqual(is_unsupported_schema("https://wedontknow.com/this-schema/metadata.json"), False)

--- a/unit-tests/unit_tests.py
+++ b/unit-tests/unit_tests.py
@@ -9,6 +9,7 @@ from test_revisions import RevisionTest
 from test_schema_transformations import CorrectifyIsniTest, CorrectifyOrcidTest, CorrectifyScopusTest
 from test_util_misc import UtilMiscTest
 from test_util_pathutil import UtilPathutilTest
+from test_util_schema_utils import SchemaUtilsTest
 from test_util_yoda_names import UtilYodaNamesTest
 from test_vault import VaultTest
 
@@ -21,6 +22,7 @@ def suite():
     test_suite.addTest(makeSuite(GroupImportTest))
     test_suite.addTest(makeSuite(PoliciesTest))
     test_suite.addTest(makeSuite(RevisionTest))
+    test_suite.addTest(makeSuite(SchemaUtilsTest))
     test_suite.addTest(makeSuite(UtilMiscTest))
     test_suite.addTest(makeSuite(UtilPathutilTest))
     test_suite.addTest(makeSuite(UtilYodaNamesTest))

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -38,6 +38,7 @@ if 'unittest' not in sys.modules:
     import arb_data_manager
     import cached_data_manager
     import irods_type_info
+    import schema_utils
 
     # Config items can be accessed directly as 'config.foo' by any module
     # that imports * from util.

--- a/util/schema_utils.py
+++ b/util/schema_utils.py
@@ -1,0 +1,25 @@
+"""This class contains utility functions related to metadata schemas."""
+
+__copyright__ = 'Copyright (c) 2025, Utrecht University'
+__license__   = 'GPLv3, see LICENSE'
+
+
+def is_unsupported_schema(schema_id: str) -> bool:
+    """
+    Determine whether schema is known to be no longer supported in current
+    version of Yoda (deprecated).
+
+    :param schema_id: Identifier of schema to get
+
+    :returns: Boolean that states whether schema ID is known to be deprecated.
+              No schema ID (value None) is also counted as unsupported, since
+              schema IDs are compulsory in the present version of Yoda. Unknown
+              schemas are considered to be not (known to be) unsupported.
+    """
+    deprecated_ids = ["https://yoda.uu.nl/schemas/{}/metadata.json".format(shortname)
+                      for shortname in
+                      ["core-0", "core-1", "default-0", "default-1", "default-2",
+                       "hptlab-0", "teclab-0"
+                       ]
+                      ]
+    return schema_id is None or schema_id in deprecated_ids

--- a/vault.py
+++ b/vault.py
@@ -1614,3 +1614,25 @@ def update_archive(ctx: rule.Context, coll: str, attr: str | None = None) -> Non
 @rule.make(inputs=[], outputs=[0])
 def rule_vault_copy_numthreads(ctx: rule.Context) -> int:
     return get_vault_copy_numthreads(ctx)
+
+
+def get_current_metadata_schema_data_package(ctx: rule.Context, coll: str) -> str | None:
+    (space, _, _, _) = pathutil.info(coll)
+    """Get metadata schema of archived data package
+
+    :param ctx:  Combined type of a callback and rei struct
+    :param coll: Path to data package
+
+    :raises ValueError: if path does not appear to refer to an archived data package
+    :returns: Current metadata schema (None if there is no schema definition in the metadata)
+    """
+    if space is not pathutil.Space.VAULT:
+        raise ValueError("Data package path is not in vault space: " + coll)
+
+    metadata_path = meta.get_latest_vault_metadata_path(ctx, coll)
+    if metadata_path is None:
+        raise ValueError("Data package metadata not found. Path probably does not refer to a data package: " + coll)
+
+    metadata = jsonutil.read(ctx, metadata_path)
+
+    return meta.metadata_get_schema_id(metadata)


### PR DESCRIPTION
When updating publication endpoints, skip data packages with metadata schemas that are known to be unsupported. Trying to generate publication data (e.g. landing pages) for such data packages does not work and results in hard-to-read log clutter, so it's better to just skip these packages with an informational message.