### PR TITLE
YDA-6527: skip faulty DPs in retention notif. job

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -229,6 +229,10 @@ def rule_process_ending_retention_packages(ctx: rule.Context) -> None:
         dp_coll = row[0]
         meta_path = meta.get_latest_vault_metadata_path(ctx, dp_coll)
 
+        if meta_path is None:
+            log.write(ctx, f"retention - No metadata found for data package <{dp_coll}>. Skipping it")
+            continue
+
         # Try to load the metadata file.
         try:
             metadata = jsonutil.read(ctx, meta_path)


### PR DESCRIPTION
In the data manager notification job for retention time of archived data packages, add error handling code for data packages without metadata.

Such data packages are invalid, but may be present on the system due to other problems. These data packages need to be ignored by the job. Log an informational message about this for technical admins.