### PR TITLE
YDA-6534: update iCommands docs link

### DIFF
--- a/tests/step_defs/ui/test_ui_data_transfer.py
+++ b/tests/step_defs/ui/test_ui_data_transfer.py
@@ -16,7 +16,7 @@ from conftest import portal_url
 
 scenarios('../../features/ui/ui_data_transfer.feature')
 
-icommands_url = "https://docs.irods.org/4.2.12/icommands/user/"
+icommands_url = "https://docs.irods.org/4.3.4/icommands/user/"
 gocommands_url = "https://github.com/cyverse/gocommands/blob/main/README.md"
 
 


### PR DESCRIPTION
Update link to iCommands documentation on data transfer page, so that it links to the iCommands version that matches the iRODS server version. Yoda should be used with an iCommands version that matches the iRODS version on the server.