### PR TITLE
yda-6136-improve-copy-to-research-codes_3

### DIFF
--- a/deposit.py
+++ b/deposit.py
@@ -14,6 +14,7 @@ from genquery import AS_DICT, Query
 import folder
 import groups
 import meta
+import vault
 from util import *
 
 __all__ = ['api_deposit_create',
@@ -40,7 +41,8 @@ def api_deposit_copy_data_package(ctx: rule.Context, reference: str, deposit_gro
         return api.Error('not_allowed', 'Could not create deposit collection.')
 
     new_deposit_path = result["deposit_path"]
-    coll_target = "/" + user.zone(ctx) + "/home/" + new_deposit_path
+    zone = user.zone(ctx)
+    coll_target = f"/{zone}/home/{new_deposit_path}"
 
     coll_data_package = ""
     iter = genquery.row_iterator(
@@ -54,8 +56,7 @@ def api_deposit_copy_data_package(ctx: rule.Context, reference: str, deposit_gro
     if coll_data_package == "":
         return api.Error('not_found', 'Could not find data package with provided reference.')
 
-    parts = coll_target.split('/')
-    group_name = parts[3]
+    _, _, group_name, _ = pathutil.info(coll_target)
 
     # Check if user has READ ACCESS to specific vault package in collection coll_data_package.
     user_full_name = user.full_name(ctx)
@@ -75,10 +76,9 @@ def api_deposit_copy_data_package(ctx: rule.Context, reference: str, deposit_gro
         return api.Error('NoWriteAccessTargetCollection', 'Not permitted to write in selected folder')
 
     # Register to delayed rule queue.
-    ctx.delayExec(
-        "<PLUSET>1s</PLUSET>",
-        "iiCopyFolderToResearch('{}', '{}')".format(coll_data_package, coll_target),
-        "")
+    retry_count  = 1
+    wait_seconds = 0
+    vault.schedule_copy_to_research(ctx, coll_data_package, coll_target, user_full_name, retry_count, wait_seconds)
 
     return {"data": new_deposit_path}
 

--- a/iiVault.r
+++ b/iiVault.r
@@ -2,7 +2,7 @@
 # \brief     Functions to copy packages to the vault and manage permissions of vault packages.
 # \author    Paul Frederiks
 # \author    Lazlo Westerhof
-# \copyright Copyright (c) 2016-2022, Utrecht University. All rights reserved.
+# \copyright Copyright (c) 2016-2025, Utrecht University. All rights reserved.
 # \license   GPLv3, see LICENSE.
 
 
@@ -287,4 +287,10 @@ iiAdminVaultActions() {
 #
 iiAdminVaultArchive(*coll, *action) {
 	msiExecCmd("admin-vault-archive.sh", uuClientFullName ++ " " ++ *coll ++ " " ++ *action, "", "", 0, *out);
+}
+
+# \brief Perform copy to research from vault
+#
+iiAdminVaultCopyToResearch(*coll, *target, *receiver, *retryCount) {
+	msiExecCmd("admin-copy-to-research.sh", uuClientFullName  ++ " " ++ *coll  ++ " " ++ *target  ++ " " ++ *receiver  ++ " " ++ *retryCount, "", "", 0, *out);
 }

--- a/iiVault.r
+++ b/iiVault.r
@@ -5,106 +5,6 @@
 # \copyright Copyright (c) 2016-2025, Utrecht University. All rights reserved.
 # \license   GPLv3, see LICENSE.
 
-
-# \brief Called by uuTreeWalk for each collection and dataobject to copy to the vault.
-#
-# \param[in] itemParent
-# \param[in] itemName
-# \param[in] itemIsCollection
-# \param[in/out] buffer
-# \param[in/out] error
-#
-iiIngestObject(*itemParent, *itemName, *itemIsCollection, *buffer, *error) {
-	*sourcePath = "*itemParent/*itemName";
-	msiCheckAccess(*sourcePath, "read_object", *readAccess);
-	if (*readAccess != 1) {
-		*error = errorcode(msiSetACL("default", "admin:read", uuClientFullName, *sourcePath));
-		if (*error < 0) {
-			*buffer.msg = "Failed to acquire read access to *sourcePath";
-			succeed;
-		} else {
-			writeLine("stdout", "iiIngestObject: Read access to *sourcePath acquired");
-		}
-	}
-
-	*destPath = *buffer.destination;
-	if (*sourcePath != *buffer."source") {
-		# rewrite path to copy objects that are located underneath the toplevel collection
-		*sourceLength = strlen(*sourcePath);
-		*relativePath = substr(*sourcePath, strlen(*buffer."source") + 1, *sourceLength);
-		*destPath = *buffer."destination" ++ "/" ++ *relativePath;
-		*markIncomplete = false;
-	} else {
-		*markIncomplete = true;
-	}
-
-	if (*itemIsCollection) {
-		*error = errorcode(msiCollCreate(*destPath, 1, *status));
-		if (*error < 0) {
-			*buffer.msg = "Failed to create collection *destPath";
-		} else if (*markIncomplete) {
-			# The root collection of the vault package is marked incomplete until the last step in FolderSecure
-			*vaultStatus = IIVAULTSTATUSATTRNAME;
-			msiString2KeyValPair("*vaultStatus=" ++ INCOMPLETE, *kvp);
-			msiAssociateKeyValuePairsToObj(*kvp, *destPath, "-C");
-		}
-	} else {
-	    # Copy data object to vault and compute checksum.
-	    *resource = "";
-		*numThreads = "";
-	    *err1 = errorcode(rule_resource_vault(*resource));
-		*err2 = errorcode(rule_vault_copy_numthreads(*numThreads));
-	    *error = errorcode(msiDataObjCopy(*sourcePath, *destPath, "destRescName=" ++ *resource ++ "++++numThreads=" ++ *numThreads ++ "++++verifyChksum=", *status));
-	    if (*error < 0) {
-		    *buffer.msg = "Failed to copy *sourcePath to *destPath";
-	    }
-	}
-	if (*readAccess != 1) {
-		*error = errorcode(msiSetACL("default", "admin:null", uuClientFullName, *sourcePath));
-		if (*error < 0) {
-			*buffer.msg = "Failed to revoke read access to *sourcePath";
-		} else {
-			writeLine("stdout", "iiIngestObject: Read access to *sourcePath revoked");
-		}
-	}
-}
-
-# \brief Called by uuTreeWalk for each collection and dataobject to copy to the research area.
-#
-# \param[in] itemParent
-# \param[in] itemName
-# \param[in] itemIsCollection
-# \param[in/out] buffer
-# \param[in/out] error
-#
-iiCopyObject(*itemParent, *itemName, *itemIsCollection, *buffer, *error) {
-	*sourcePath = "*itemParent/*itemName";
-	*destPath = *buffer.destination;
-
-	if (*sourcePath != *buffer."source") {
-		# rewrite path to copy objects that are located underneath the toplevel collection
-		*sourceLength = strlen(*sourcePath);
-		*relativePath = substr(*sourcePath, strlen(*buffer."source") + 1, *sourceLength);
-		*destPath = *buffer."destination" ++ "/" ++ *relativePath;
-	}
-
-	if (*itemIsCollection) {
-		*error = errorcode(msiCollCreate(*destPath, 1, *status));
-		if (*error < 0) {
-			*buffer.msg = "Failed to create collection *destPath";
-		}
-	} else {
-		*resource = "";
-		*numThreads = "";
-		*err1 = errorcode(rule_resource_research(*resource));
-		*err2 = errorcode(rule_vault_copy_numthreads(*numThreads));
-	    *error = errorcode(msiDataObjCopy(*sourcePath, *destPath, "destRescName=" ++ *resource ++ "++++numThreads=" ++ *numThreads ++ "++++verifyChksum=", *status));
-		if (*error < 0) {
-			*buffer.msg = "Failed to copy *sourcePath to *destPath";
-		}
-	}
-}
-
 #\ Generic secure copy functionality
 # \param[in] argv         argument string for secure copy like "*publicHost inbox /var/www/landingpages/*publicPath";
 # \param[in] origin_path  local path of origin file
@@ -155,28 +55,6 @@ iiCopyACLsFromParent(*path, *recursiveFlag) {
         }
 }
 
-# \brief Copy a vault package to the research area.
-#
-# \param[in] folder  folder to copy from the vault
-# \param[in] target  path of the research area target
-#
-iiCopyFolderToResearch(*folder, *target) {
-        writeLine("stdout", "iiCopyFolderToResearch: Copying *folder to *target.");
-
-        # Determine target collection group and actor.
-        *pathElems = split(*folder, "/");
-        *elemSize = size(*pathElems);
-        *vaultPackage = elem(*pathElems, *elemSize - 1);
-
-        *buffer.source = *folder;
-        *buffer.destination = *target ++ "/" ++ *vaultPackage;
-        uuTreeWalk("forward", *folder, "iiCopyObject", *buffer, *error);
-        if (*error != 0) {
-                msiGetValByKey(*buffer, "msg", *msg); # using . syntax here lead to type error
-                writeLine("stdout", "iiCopyObject: *error: *msg");
-                fail;
-        }
-}
 
 # \brief Retrieve current vault folder status
 #

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -20,6 +20,7 @@ import meta
 import research
 import schema
 from util import api, avu, collection, config, constants, data_object, diff_data, group, jsonutil, log, measure_coverage, msi, resources, rule, user
+from vault import copy_folder_to_research
 
 
 def _call_msvc_stat_vault(ctx, resc_name, data_path):
@@ -866,6 +867,9 @@ basic_integration_tests = [
      "check": lambda x: x is True},
     {"name": "hashes_collection.identical_collections",
      "test": lambda ctx: test_hashes_on_identical_collections(ctx),
+     "check": lambda x: x is True},
+    {"name": "copy_folder_to_research.copied_correctly",
+     "test": lambda ctx: _test_copy_folder_to_research(ctx),
      "check": lambda x: x is True}
 ]
 
@@ -1114,3 +1118,50 @@ def test_hashes_on_identical_collections(ctx):
     collection.remove(ctx, coll2)
 
     return hash1 == hash2
+
+
+def _test_copy_folder_to_research(ctx):
+    """Test for copy-to-research's irsync function. Verify
+    if files are copied correctly to research space.
+
+    :param ctx: combined type of a callback and rei struct
+
+    :returns: true if collection is copied to desinated research space
+                and permissions are correctly set, else false
+    """
+
+    # Generate unique test identifiers
+    test_id = str(uuid.uuid4())
+    zone = user.zone(ctx)
+
+    # Create test collections
+    vault_origin = f"/{zone}/home/vault-initial/test_{test_id}"
+    research_target = f"/{zone}/home/research-initial/test_{test_id}"
+
+    try:
+        # Setup origin in vault
+        collection.create(ctx, vault_origin)
+        data_object.write(ctx, f"{vault_origin}/test_file.txt", "TEST_CONTENT")
+
+        # Execute the copy operation
+        success = copy_folder_to_research(ctx, vault_origin, research_target)
+        # Verify results
+        results = {
+            "success": success,
+            "target_exists": collection.exists(ctx, f"{research_target}"),
+            "file_copied": data_object.exists(ctx, f"{research_target}/test_file.txt"),
+        }
+
+        return all(results.values())
+
+    except Exception as e:
+        log.write(ctx, f"Test exception: {str(e)}")
+        return False
+    finally:
+        # Cleanup regardless of test outcome
+        for path in [vault_origin, research_target]:
+            try:
+                if collection.exists(ctx, path):
+                    collection.remove(ctx, path)
+            except Exception as e:
+                log.write(ctx, f"Clean up test files exception: {str(e)}")

--- a/notifications.py
+++ b/notifications.py
@@ -82,11 +82,14 @@ def api_notifications_load(ctx: rule.Context, sort_order: str = "desc") -> List:
             notification["datetime"] = (datetime.fromtimestamp(notification["timestamp"])).strftime('%Y-%m-%d %H:%M')
             notification["actor"] = user.from_str(ctx, notification["actor"])[0]
 
-            # Get data package and link from target path for research and vault packages.
+            # Get data package and link from target path for research, deposit and vault packages.
             space, _, group, subpath = pathutil.info(notification["target"])
             if space is pathutil.Space.RESEARCH:
                 notification["data_package"] = group if subpath == '' else pathutil.basename(subpath)
                 notification["link"] = "/research/browse?dir=" + urllib.parse.quote(f"/{group}/{subpath}")
+            elif space is pathutil.Space.DEPOSIT:
+                notification["data_package"] = group if subpath == '' else pathutil.basename(subpath)
+                notification["link"] = "/deposit/data?dir=" + urllib.parse.quote(f"/{group}/{subpath}")
             elif space is pathutil.Space.VAULT:
                 notification["data_package"] = group if subpath == '' else pathutil.basename(subpath)
                 notification["link"] = "/vault/browse?dir=" + urllib.parse.quote(f"/{group}/{subpath}")

--- a/tests/features/api/api_deposit_open.feature
+++ b/tests/features/api/api_deposit_open.feature
@@ -67,3 +67,10 @@ Feature: Deposit API (open)
         Examples:
             | collection                 |
             | /tempZone/home/vault-pilot |
+
+
+    Scenario Outline: Deposit copy data package
+        Given user researcher is authenticated
+        And archived deposit exists
+        And the Yoda deposit copy data package API is queried
+        Then the response status code is "200"

--- a/tests/features/api/api_vault.feature
+++ b/tests/features/api/api_vault.feature
@@ -238,3 +238,15 @@ Feature: Vault API
             | /tempZone/home/vault-core-2     |
             | /tempZone/home/vault-default-3  |
             | /tempZone/home/vault-epos-msl-0 |
+
+
+    Scenario Outline: Vault copy to research space
+        Given user researcher is authenticated
+        And data package exists in <vault>
+        And the Yoda vault copy to research space API is queried with <vault> and <research>
+        Then the response status code is "200"
+        And data package exists in <research>
+
+        Examples:
+            | vault                         | research                       |
+            | /tempZone/home/vault-core-0   | /tempZone/home/research-core-0 |

--- a/tests/step_defs/api/common_vault.py
+++ b/tests/step_defs/api/common_vault.py
@@ -158,6 +158,15 @@ def api_meta_form_save_vault(user, vault, data_package):
     )
 
 
+@given(parsers.parse('the Yoda vault copy to research space API is queried with {vault} and {research}'), target_fixture="api_response")
+def api_vault_copy_to_research_space(user, vault, data_package, research):
+    return api_request(
+        user,
+        "vault_copy_to_research",
+        {"coll_origin": vault + "/" + data_package, "coll_target": research}
+    )
+
+
 @then(parsers.parse('data package in {vault} status is "{status}"'))
 def data_package_status(user, vault, data_package, status):
     for _i in range(25):
@@ -223,3 +232,21 @@ def published_packages(api_response):
     http_status, body = api_response
     assert http_status == 200
     assert len(body["data"]) > 0
+
+
+@then(parsers.parse("data package exists in {research}"))
+def api_research_data_package(user, data_package, research):
+    for _i in range(30):
+        http_status, body = api_request(
+            user,
+            "browse_collections",
+            {"coll": research, "sort_order": "desc"}
+        )
+        assert http_status == 200
+
+        for item in body["data"]["items"]:
+            if item["name"] == data_package:
+                return True
+        time.sleep(5)
+    # If we reach this point, the data package was not found
+    raise AssertionError()

--- a/tests/step_defs/api/test_api_deposit.py
+++ b/tests/step_defs/api/test_api_deposit.py
@@ -6,6 +6,7 @@ __license__   = 'GPLv3, see LICENSE'
 
 import json
 import os
+import re
 import time
 from collections import OrderedDict
 from urllib.parse import urlparse
@@ -58,6 +59,19 @@ def deposit_is_archived(user):
     time.sleep(45)
 
 
+@given('archived deposit exists', target_fixture="deposit_name")
+def deposit_archive_exists(user):
+    http_status, body = api_request(
+        user,
+        "browse_collections",
+        {"coll": "/tempZone/home/vault-pilot", "sort_order": "desc"}
+    )
+
+    assert http_status == 200
+    assert len(body["data"]["items"]) > 0
+    return body["data"]["items"][0]["name"]
+
+
 @given('the Yoda deposit status API is queried', target_fixture="api_response")
 def api_deposit_status(user, deposit_name):
     return api_request(
@@ -73,6 +87,34 @@ def api_deposit_clear(user, deposit_name):
         user,
         "deposit_submit",
         {"path": "/deposit-pilot/{}".format(deposit_name)}
+    )
+
+
+@given('the Yoda deposit copy data package API is queried', target_fixture="api_response")
+def api_deposit_copy_data_package(user, deposit_name):
+    _, body = api_request(
+        user,
+        "vault_system_metadata",
+        {"coll": f"/tempZone/home/vault-pilot/{deposit_name}"}
+    )
+    assert "Data Package Reference" in body["data"]
+
+    # Regex to match the data package reference.
+    uuid_pattern = r'([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
+
+    # Search for the data package reference response body.
+    match = re.search(uuid_pattern, body["data"]["Data Package Reference"])
+
+    # Check if a data package reference was found
+    if match:
+        reference = match.group(1)
+    else:
+        raise AssertionError(f"No reference found for {deposit_name}")
+
+    return api_request(
+        user,
+        "deposit_copy_data_package",
+        {"reference": reference, "deposit_group": "deposit-pilot"}
     )
 
 

--- a/tools/admin/admin-copy-to-research.sh
+++ b/tools/admin/admin-copy-to-research.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+actor="$1"
+coll_origin="$2"
+coll_target="$3"
+retry_str="$4"
+receiver="$actor"
+
+irule -r irods_rule_engine_plugin-irods_rule_language-instance \
+      -F /etc/irods/yoda-ruleset/tools/copy-to-research.r \
+      "*actor=\"${actor}\"" \
+      "*coll_origin=\"${coll_origin}\"" \
+      "*coll_target=\"${coll_target}\"" \
+      "*receiver=\"${receiver}\"" \
+      "*retry_str=\"${retry_str}\""

--- a/tools/copy-to-research.r
+++ b/tools/copy-to-research.r
@@ -1,0 +1,11 @@
+#!/usr/bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
+
+copyToResearch {
+    # Try to copy vault data package to research.
+    # This script is kept as dumb as possible.
+    # All processing and error handling is done by rule_vault_copy_to_research
+    rule_vault_copy_to_research(*coll_origin, *coll_target, *receiver, *retry_str);
+}
+
+INPUT *actor="", *coll_origin="", *coll_target="", *receiver="", *retry_str=""
+OUTPUT ruleExecOut

--- a/tools/copy-to-vault.r
+++ b/tools/copy-to-vault.r
@@ -1,10 +1,11 @@
-#!/usr/bin/irule -F
+#!/usr/bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
 
 copyToVault {
-	# Try to copy accepted and retry research folders to vault.
-	# This script is kept as dumb as possible.
-	# All processing and error handling is done by rule_vault_copy_to_vault
-	rule_vault_copy_to_vault();
+    # Try to copy accepted and retry research folders to vault.
+    # This script is kept as dumb as possible.
+    # All processing and error handling is done by rule_vault_copy_to_vault
+    rule_vault_copy_to_vault();
 }
-input null
-output ruleExecOut
+
+INPUT null
+OUTPUT ruleExecOut

--- a/unit-tests/test_vault.py
+++ b/unit-tests/test_vault.py
@@ -8,22 +8,26 @@ from unittest import TestCase
 
 sys.path.append('..')
 
-from vault_utils import get_copy_folder_to_vault_irsync_command, get_sanity_checks_results_copy_to_vault_paths
+from vault_utils import get_copy_irsync_command, get_sanity_checks_results_copy_to_research_paths, get_sanity_checks_results_copy_to_vault_paths
 
 
 class VaultTest(TestCase):
 
-    def test_get_copy_folder_to_vault_irsync_command_with_vault_resc(self):
-        output = get_copy_folder_to_vault_irsync_command("/zoneName/home/research-foo/abc", "/zoneName/home/vault-foo/abc", "vaultResc", True)
+    def test_get_copy_irsync_command_with_vault_resc(self):
+        output = get_copy_irsync_command("/zoneName/home/research-foo/abc", "/zoneName/home/vault-foo/abc/original", "vaultResc", True)
         self.assertEqual(output, ["irsync", "-rK", "-R", "vaultResc", "i:/zoneName/home/research-foo/abc/", "i:/zoneName/home/vault-foo/abc/original"])
 
-    def test_get_copy_folder_to_vault_irsync_command_without_vault_resc(self):
-        output = get_copy_folder_to_vault_irsync_command("/zoneName/home/research-foo/abc", "/zoneName/home/vault-foo/abc", None, True)
+    def test_get_copy_irsync_command_without_vault_resc(self):
+        output = get_copy_irsync_command("/zoneName/home/research-foo/abc", "/zoneName/home/vault-foo/abc/original", None, True)
         self.assertEqual(output, ["irsync", "-rK", "i:/zoneName/home/research-foo/abc/", "i:/zoneName/home/vault-foo/abc/original"])
 
-    def test_get_copy_folder_to_vault_irsync_command_no_multithreading(self):
-        output = get_copy_folder_to_vault_irsync_command("/zoneName/home/research-foo/abc", "/zoneName/home/vault-foo/abc", "vaultResc", False)
+    def test_get_copy_irsync_command_no_multithreading(self):
+        output = get_copy_irsync_command("/zoneName/home/research-foo/abc", "/zoneName/home/vault-foo/abc/original", "vaultResc", False)
         self.assertEqual(output, ["irsync", "-rK", "-R", "vaultResc", "-N", "0", "i:/zoneName/home/research-foo/abc/", "i:/zoneName/home/vault-foo/abc/original"])
+
+    def test_get_copy_irsync_command_copy_from_research_mode(self):
+        output = get_copy_irsync_command("/zoneName/home/vault-foo/abc", "/zoneName/home/research-foo/abc", None, False)
+        self.assertEqual(output, ["irsync", "-rK", "-N", "0", "i:/zoneName/home/vault-foo/abc/", "i:/zoneName/home/research-foo/abc"])
 
     def test_get_sanity_check_results_copy_to_vault_paths_ok(self):
         output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo", "/tempZone/home/vault-foo")
@@ -56,3 +60,31 @@ class VaultTest(TestCase):
     def test_get_sanity_check_results_copy_to_vault_paths_source_target_mismatch(self):
         output = get_sanity_checks_results_copy_to_vault_paths("/tempZone/home/research-foo", "/tempZone/home/vault-bar")
         self.assertEqual(output, ["Source and target group are not in same compartment."])
+
+    def test_get_sanity_check_results_copy_to_research_paths_ok(self):
+        output = get_sanity_checks_results_copy_to_research_paths("/tempZone/home/vault-foo", "/tempZone/home/research-foo")
+        self.assertEqual(output, [])
+
+    def test_get_sanity_check_results_copy_to_research_paths_relative_source(self):
+        output = get_sanity_checks_results_copy_to_research_paths("vault-foo", "/tempZone/home/research-foo")
+        self.assertEqual(output, ["Source path is not absolute."])
+
+    def test_get_sanity_check_results_copy_to_research_paths_relative_target(self):
+        output = get_sanity_checks_results_copy_to_research_paths("/tempZone/home/vault-foo", "research-foo")
+        self.assertEqual(output, ["Target path is not absolute."])
+
+    def test_get_sanity_check_results_copy_to_research_paths_dotdot_source(self):
+        output = get_sanity_checks_results_copy_to_research_paths("/tempZone/home/vault-foo/..", "/tempZone/home/research-foo")
+        self.assertEqual(output, ["Source path contains parent references (..)"])
+
+    def test_get_sanity_check_results_copy_to_research_paths_dotdot_target(self):
+        output = get_sanity_checks_results_copy_to_research_paths("/tempZone/home/vault-foo", "/tempZone/home/../research-foo")
+        self.assertEqual(output, ["Target path contains parent references (..)"])
+
+    def test_get_sanity_check_results_copy_to_research_paths_wrong_source_space(self):
+        output = get_sanity_checks_results_copy_to_research_paths("/tempZone/home/research-foo", "/tempZone/home/research-bar")
+        self.assertEqual(output, ["Source path not in vault group."])
+
+    def test_get_sanity_check_results_copy_to_research_paths_wrong_target_space(self):
+        output = get_sanity_checks_results_copy_to_research_paths("/tempZone/home/vault-foo", "/tempZone/home/vault-bar")
+        self.assertEqual(output, ["Target path not in research or deposit group."])

--- a/vault.py
+++ b/vault.py
@@ -18,10 +18,11 @@ import folder
 import groups
 import meta
 import meta_form
+import notifications
 import policies_datamanager
 import policies_datapackage_status
 from util import *
-from vault_utils import get_copy_folder_to_vault_irsync_command, get_sanity_checks_results_copy_to_vault_paths
+from vault_utils import get_copy_irsync_command, get_sanity_checks_results_copy_to_research_paths, get_sanity_checks_results_copy_to_vault_paths
 
 __all__ = ['api_vault_submit',
            'api_vault_approve',
@@ -30,6 +31,7 @@ __all__ = ['api_vault_submit',
            'api_vault_republish',
            'api_vault_preservable_formats_lists',
            'api_vault_unpreservable_files',
+           'rule_vault_copy_to_research',
            'rule_vault_copy_to_vault',
            'rule_vault_copy_numthreads',
            'rule_vault_copy_original_metadata_to_vault',
@@ -182,42 +184,38 @@ def api_vault_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target:
 
     :returns: API status
     """
-    zone = user.zone(ctx)
+    coll_target = coll_target.rstrip('/')
+    coll_origin = coll_origin.rstrip('/')
 
-    # API error introduces post-error in requesting application.
-    if coll_target == "/" + zone + "/home":
-        return api.Error('HomeCollectionNotAllowed', 'Please select a specific research folder for your datapackage')
+    # Validate origin location.
+    space, _, _, _ = pathutil.info(coll_origin)
+    if space is not pathutil.Space.VAULT:
+        return api.Error('RequiredVaultOrigin', 'Please select a specific vault datapackage to copy')
 
-    # Check if target is a research folder. I.e. none-vault folder.
-    parts = coll_target.split('/')
-    group_name = parts[3]
-    if group_name.startswith('vault-'):
+    # Validate target location.
+    space, _, group_name, _ = pathutil.info(coll_target)
+    if space is not pathutil.Space.RESEARCH:
         return api.Error('RequiredIsResearchArea', 'Please select a specific research folder for your datapackage')
 
-    # Check whether datapackage folder already present in target folder.
-    # Get package name from origin path
-    parts = coll_origin.split('/')
-    new_package_collection = coll_target + '/' + parts[-1]
+    # Concatenate coll_target with package name to create sub_coll_target.
+    _, package_name = pathutil.chop(coll_origin)
+    sub_coll_target = f'{coll_target}/{package_name}'
 
-    # Now check whether target collection already exist.
-    if collection.exists(ctx, new_package_collection):
-        return api.Error('PackageAlreadyPresentInTarget', 'This datapackage is already present at the specified place')
-
-    # Check if target path exists.
+    # Verify target collection exists (parent of sub_coll_target).
     if not collection.exists(ctx, coll_target):
         return api.Error('TargetPathNotExists', 'The target you specified does not exist')
 
-    # Check if user has READ ACCESS to specific vault package in collection coll_origin.
+    # Verify sub_coll_target package NOT already exists.
+    if collection.exists(ctx, sub_coll_target):
+        return api.Error('PackageAlreadyPresentInTarget', 'This datapackage is already present at the specified location')
+
+    # Check user permissions.
     user_full_name = user.full_name(ctx)
-    category = groups.group_category(ctx, group_name)
-    is_datamanager = groups.user_is_datamanager(ctx, category, user.full_name(ctx))
+    category       = groups.group_category(ctx, group_name)
+    is_datamanager = groups.user_is_datamanager(ctx, category, user_full_name)
 
-    if not is_datamanager:
-        # Check if research group has access by checking of research-group exists for this user.
-        research_group_access = collection.exists(ctx, coll_origin)
-
-        if not research_group_access:
-            return api.Error('NoPermissions', 'Insufficient rights to perform this action')
+    if not is_datamanager and not collection.exists(ctx, coll_origin):
+        return api.Error('NoPermissions', 'Insufficient rights to perform this action')
 
     # Check for possible locks on target collection.
     lock_count = meta_form.get_coll_lock_count(ctx, coll_target)
@@ -226,21 +224,145 @@ def api_vault_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target:
 
     # Check if user has write access to research folder.
     # Only normal user has write access.
-    if groups.user_role(ctx, user_full_name, group_name) not in ['normal', 'manager']:
+    user_role = groups.user_role(ctx, user_full_name, group_name)
+    if user_role not in ['normal', 'manager']:
         return api.Error('NoWriteAccessTargetCollection', 'Not permitted to write in selected folder')
 
-    # Register to delayed rule queue.
-    delay = 10
+    # Schedule immediate execution
+    # This uses delay server to run irule in backend
+    # Which ensures the initial copy and following retry calls are consistent in behavior
+    # Also to avoid timeout issues with large data copies, counterexample: run with rule.call directly
+    retry_count  = 1
+    wait_seconds = 0
 
+    schedule_copy_to_research(ctx, coll_origin, sub_coll_target, user_full_name, retry_count, wait_seconds)
+
+    return {
+        "status": "ok",
+        "target": sub_coll_target,
+        "origin": coll_origin
+    }
+
+
+def schedule_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target: str, actor: str, retry_count: int, wait_seconds: int) -> None:
+    """
+    A help function to call `msiExecCmd("admin-copy-to-research.sh", …)` job
+    through the delay server.
+
+    :param ctx:          Combined type of a callback and rei struct
+    :param coll_origin:  Origin data collection in vault space
+    :param coll_target:  Target collection path in research space
+    :param actor:        User to notify of success/failure
+    :param retry_count:  Current retry attempt as int
+    :param wait_seconds: Delay in seconds
+    """
     ctx.delayExec(
-        "<PLUSET>%ds</PLUSET>" % delay,
-        "iiCopyFolderToResearch('{}', '{}')".format(coll_origin, coll_target),
+        f"<PLUSET>{wait_seconds}s</PLUSET>",
+        f"iiAdminVaultCopyToResearch('{coll_origin}', '{coll_target}', '{actor}', '{retry_count}')",
         "")
 
-    # TODO: response nog veranderen
-    return {"status": "ok",
-            "target": coll_target,
-            "origin": coll_origin}
+
+@rule.make(inputs=[0, 1, 2, 3], outputs=[])
+def rule_vault_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target: str, actor: str, retry_str: str) -> None:
+    """Orchestrate vault copy-to-research operation with retry handling.
+    If the copy operation fails, it will be retried up to a maximum number of times.
+
+    :param ctx:         Combined type of a callback and rei struct
+    :param coll_origin: Origin data collection in vault space
+    :param coll_target: Target collection in research space
+    :param actor:       User to notify of success/failure
+    :param retry_str:   Current retry attempt as string
+
+    :returns:           True if operation succeeded or entered retry logic, False if target already existed
+    """
+    log.write(ctx, f"Starting vault copy to research: {coll_origin} -> {coll_target}, attempt #{retry_str}")
+
+    # Check target already existed during the retry process, to prevent double clicking
+    if collection.exists(ctx, coll_target):
+        log.write(ctx, f"Target collection already exists: {coll_target}")
+        return None
+
+    # Execute copy operation through irsync cmd
+    success = copy_folder_to_research(ctx, coll_origin, coll_target)
+
+    # Handle result
+    if success:
+        notifications.set(ctx, "system", actor, coll_target, "Copy data package to research space finished")
+        log.write(ctx, f"Copy successful: {coll_origin}")
+        return None
+
+    # Copy failed and enter retry logic
+    retry_count = int(retry_str)
+    handle_retry_operation(ctx, coll_origin, coll_target, actor, retry_count)
+
+
+def copy_folder_to_research(ctx: rule.Context, coll: str, target: str) -> bool:
+    """Copy vault data package and all its contents to target in research using irsync.
+
+    :param ctx:    Combined type of a callback and rei struct
+    :param coll:   Path of a folder in the vault space
+    :param target: Path of a package in the research space
+
+    :returns: True for successful copy
+    """
+    sanity_check_results = get_sanity_checks_results_copy_to_research_paths(coll, target)
+    if len(sanity_check_results) > 0:
+        log.write(ctx, "Not copying folder to research because of sanity check failures: "
+                  + str(sanity_check_results))
+        return False
+
+    admin = user.full_name(ctx)
+    parent, _ = pathutil.chop(target)
+    msi.set_acl(ctx, "recursive", "admin:write", admin, parent)
+
+    returncode = 0
+    irsync_command = get_copy_irsync_command(coll,
+                                             target,
+                                             config.resource_vault,
+                                             config.vault_copy_multithread_enabled)
+
+    try:
+        returncode = subprocess.call(irsync_command)
+    except Exception as e:
+        log.write(ctx, "irsync failure: " + str(e))
+        log.write(ctx, "irsync failure for coll <{}> and target <{}>".format(coll, target))
+        return False
+
+    if returncode != 0:
+        log.write(ctx, "irsync failure for coll <{}> and target <{}>".format(coll, target))
+        return False
+
+    return True
+
+
+def handle_retry_operation(ctx: rule.Context, coll_origin: str, coll_target: str, actor: str, retry_count: int) -> bool:
+    """Manage retry logic with delays for copy-to-research workflow
+
+    :param ctx:         Combined type of a callback and rei struct
+    :param coll_origin: Origin data collection in vault space
+    :param coll_target: Target data collection in research space
+    :param actor:       User to notify of success/failure
+    :param retry_count: Current retry attempt as integer
+
+    :returns:           True if retry scheduled, False if max retries exceeded or scheduling failed
+    """
+    log.write(ctx, f"Copy failed: {coll_origin} for {actor}, entering retry logic, attempt #{retry_count}")
+
+    max_retries = config.vault_copy_max_retries
+    wait_seconds = config.vault_copy_backoff_time  # in seconds
+
+    if retry_count >= max_retries:
+        log.write(ctx, f"Max retries exceeded for copy_to_research: {coll_origin}")
+        notifications.set(ctx, "system", actor, coll_target, "Copy data package to research space failed, max retries exceeded")
+        return False
+
+    next_attempt  = retry_count + 1
+    log.write(ctx, f"Scheduled attempt #{next_attempt} in {wait_seconds}s for: {coll_origin}")
+
+    # one single call, identical path through the delay server
+    schedule_copy_to_research(ctx, coll_origin, coll_target, actor, next_attempt, wait_seconds)
+
+    return True
 
 
 @api.make()
@@ -968,10 +1090,10 @@ def copy_folder_to_vault(ctx: rule.Context, coll: str, target: str) -> bool:
         return False
 
     returncode = 0
-    irsync_command = get_copy_folder_to_vault_irsync_command(coll,
-                                                             target,
-                                                             config.resource_vault,
-                                                             config.vault_copy_multithread_enabled)
+    irsync_command = get_copy_irsync_command(coll,
+                                             f"{target}/original",
+                                             config.resource_vault,
+                                             config.vault_copy_multithread_enabled)
 
     try:
         returncode = subprocess.call(irsync_command)

--- a/vault.py
+++ b/vault.py
@@ -228,13 +228,9 @@ def api_vault_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target:
     if user_role not in ['normal', 'manager']:
         return api.Error('NoWriteAccessTargetCollection', 'Not permitted to write in selected folder')
 
-    # Schedule immediate execution
-    # This uses delay server to run irule in backend
-    # Which ensures the initial copy and following retry calls are consistent in behavior
-    # Also to avoid timeout issues with large data copies, counterexample: run with rule.call directly
+    # Register to delayed rule queue.
     retry_count  = 1
     wait_seconds = 0
-
     schedule_copy_to_research(ctx, coll_origin, sub_coll_target, user_full_name, retry_count, wait_seconds)
 
     return {
@@ -269,16 +265,18 @@ def rule_vault_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target
 
     :param ctx:         Combined type of a callback and rei struct
     :param coll_origin: Origin data collection in vault space
-    :param coll_target: Target collection in research space
+    :param coll_target: Target collection in research or deposit space
     :param actor:       User to notify of success/failure
     :param retry_str:   Current retry attempt as string
 
     :returns:           True if operation succeeded or entered retry logic, False if target already existed
     """
-    log.write(ctx, f"Starting vault copy to research: {coll_origin} -> {coll_target}, attempt #{retry_str}")
+    log.write(ctx, f"Starting vault copy: {coll_origin} -> {coll_target}, attempt #{retry_str}")
+
+    space, _, _, _ = pathutil.info(coll_target)
 
     # Check target already existed during the retry process, to prevent double clicking
-    if collection.exists(ctx, coll_target):
+    if space is pathutil.Space.RESEARCH and collection.exists(ctx, coll_target):
         log.write(ctx, f"Target collection already exists: {coll_target}")
         return None
 
@@ -287,13 +285,17 @@ def rule_vault_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target
 
     # Handle result
     if success:
-        notifications.set(ctx, "system", actor, coll_target, "Copy data package to research space finished")
-        log.write(ctx, f"Copy successful: {coll_origin}")
-        return None
+        # Fix ACLs for data package copied to deposit.
+        if space is pathutil.Space.DEPOSIT:
+            msi.set_acl(ctx, "recursive", "admin:own", actor, coll_target)
 
-    # Copy failed and enter retry logic
-    retry_count = int(retry_str)
-    handle_retry_operation(ctx, coll_origin, coll_target, actor, retry_count)
+        _, _, _, datapackage_name = pathutil.info(coll_origin)
+        notifications.set(ctx, "system", actor, coll_target, f"Copying data package <{datapackage_name}>finished")
+        log.write(ctx, f"Copy successful: {coll_origin}")
+    else:
+        # Copy failed and enter retry logic
+        retry_count = int(retry_str)
+        handle_retry_operation(ctx, coll_origin, coll_target, actor, retry_count)
 
 
 def copy_folder_to_research(ctx: rule.Context, coll: str, target: str) -> bool:
@@ -352,8 +354,9 @@ def handle_retry_operation(ctx: rule.Context, coll_origin: str, coll_target: str
     wait_seconds = config.vault_copy_backoff_time  # in seconds
 
     if retry_count >= max_retries:
+        _, _, _, datapackage_name = pathutil.info(coll_origin)
         log.write(ctx, f"Max retries exceeded for copy_to_research: {coll_origin}")
-        notifications.set(ctx, "system", actor, coll_target, "Copy data package to research space failed, max retries exceeded")
+        notifications.set(ctx, "system", actor, coll_origin, "Copying data package <{datapackage_name}> failed, max retries exceeded")
         return False
 
     next_attempt  = retry_count + 1

--- a/vault_utils.py
+++ b/vault_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for vault module."""
 
-__copyright__ = 'Copyright (c) 2019-2024, Utrecht University'
+__copyright__ = 'Copyright (c) 2019-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 from typing import List, Union
@@ -8,18 +8,16 @@ from typing import List, Union
 from util import pathutil
 
 
-def get_copy_folder_to_vault_irsync_command(coll: str, target: str, vault_resource: Union[str, None], multi_threading: bool) -> List[str]:
-    """Internal function to determine rsync command for copy-to-vault
+def get_copy_irsync_command(coll: str, target: str, vault_resource: Union[str, None], multi_threading: bool) -> List[str]:
+    """Internal function to determine irsync command for copy-to-vault and copy-to-research.
 
-       :param coll: source collection
-       :param target: target collection
-       :param vault_resource: resource to store vault data on (can be None)
-       :param multi_threading: if set to false, disable multi threading,
-                               otherwise use server default
+    :param coll:            Source collection
+    :param target:          Target collection
+    :param vault_resource:  Resource to store data on (can be None)
+    :param multi_threading: If False, disable multi threading, otherwise use server default
 
-       :returns: irsync command with parameters in list format
+    :returns: irsync command with parameters in list format
     """
-
     irsync_command: List[str] = ["irsync", "-rK"]
 
     if vault_resource is not None:
@@ -28,8 +26,49 @@ def get_copy_folder_to_vault_irsync_command(coll: str, target: str, vault_resour
     if not multi_threading:
         irsync_command.extend(["-N", "0"])  # 0 means no multi threading
 
-    irsync_command.extend(["i:{}/".format(coll), "i:{}/original".format(target)])
+    irsync_command.extend([f"i:{coll}/", f"i:{target}"])
+
     return irsync_command
+
+
+def get_sanity_checks_results_copy_to_research_paths(source: str, target: str) -> List[str]:
+    """Internal function to determine whether a source and destination path for
+       copying data from the vault pass sanity checks.
+
+       :param source: source collection
+       :param target: target collection
+
+       :returns: list of sanity check fails (empty list means all tests passed)
+    """
+    failed: List[str] = []
+
+    if not source.startswith("/"):
+        failed.append("Source path is not absolute.")
+
+    if not target.startswith("/"):
+        failed.append("Target path is not absolute.")
+
+    if ".." in source.split("/"):
+        failed.append("Source path contains parent references (..)")
+
+    if ".." in target.split("/"):
+        failed.append("Target path contains parent references (..)")
+
+    if len(failed) > 0:
+        # The remaining tests assume absolute paths without parent references,
+        # so skip these tests if previous tests did not pass.
+        return failed
+
+    (source_space, source_zone, source_group, _) = pathutil.info(source)
+    (target_space, target_zone, target_group, _) = pathutil.info(target)
+
+    if source_space != pathutil.Space.VAULT:
+        failed.append("Source path not in vault group.")
+
+    if target_space not in (pathutil.Space.DEPOSIT, pathutil.Space.RESEARCH):
+        failed.append("Target path not in research or deposit group.")
+
+    return failed
 
 
 def get_sanity_checks_results_copy_to_vault_paths(source: str, target: str) -> List[str]:


### PR DESCRIPTION
1. Improved copy-to-research flow by replacing legacy irods rule (iiCopyFolderToResearch) with irsync. This prevents potential issue of memory leakage. 
2. Piloted using delayExec for retry mechanism.
3. Added sending notification to user when copy-to-research successes or fails.  
Associated Portal PR: https://github.com/UtrechtUniversity/yoda-portal/pull/437 and https://github.com/UtrechtUniversity/yoda/pull/643/files