### PR TITLE
YDA-6554: fix DP retention time notifications

### DIFF
--- a/notifications.py
+++ b/notifications.py
@@ -226,6 +226,11 @@ def rule_process_ending_retention_packages(ctx: rule.Context) -> None:
     )
     for row in iter:
         dp_coll = row[0]
+
+        if not pathutil.is_archived_datapackage_path(dp_coll):
+            # This is not a top-level collection of an archived data package. Skip it.
+            continue
+
         meta_path = meta.get_latest_vault_metadata_path(ctx, dp_coll)
 
         if meta_path is None:

--- a/unit-tests/test_util_pathutil.py
+++ b/unit-tests/test_util_pathutil.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 sys.path.append('../util')
 
-from pathutil import basename, chop, chopext, dirname, info, Space
+from pathutil import basename, chop, chopext, dirname, info, is_archived_datapackage_path, Space
 
 
 class UtilPathutilTest(TestCase):
@@ -124,3 +124,17 @@ class UtilPathutilTest(TestCase):
         self.assertEqual(output, (Space.INTAKE, 'tempZone', 'grp-intake-test', ''))
         output = info("/tempZone/home/datarequests-test")
         self.assertEqual(output, (Space.DATAREQUEST, 'tempZone', 'datarequests-test', ''))
+
+    def test_is_archived_datapackage_path(self):
+        self.assertTrue(is_archived_datapackage_path("/tempZone/home/vault-foo/datapackage[123456]"))
+        self.assertTrue(is_archived_datapackage_path("/tempZone/home/vault-foo/data-package[123456]"))
+        self.assertTrue(is_archived_datapackage_path("/tempZone/home/vault-foo/data package[123456]"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone/home/vault-foo/collectionwithouttimestamp"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone/home/research-foo/tempZone/home/vault-foo/datapackage[123456]"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone/home/vault-foo/datapackage[123456]/original"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone/trash/home/vault-foo/datapackage[123456]"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone/yoda/schemas/default-0"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone/home/research-foo"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone/home/vault-foo"))
+        self.assertFalse(is_archived_datapackage_path("/tempZone"))
+        self.assertFalse(is_archived_datapackage_path(""))

--- a/util/pathutil.py
+++ b/util/pathutil.py
@@ -129,6 +129,6 @@ def is_archived_datapackage_path(path: str) -> bool:
 
     :param path: Path to check
 
-    :returns: True if path refers to top-leve collection of data package. Else False.
+    :returns: True if path refers to top-level collection of data package. Else False.
     """
     return bool(re.match(r"^/[^/]+/home/vault-[^/]+/[^/]+\[\d+\]$", path))

--- a/util/pathutil.py
+++ b/util/pathutil.py
@@ -122,3 +122,13 @@ def info(path: str) -> Tuple[Space, str, str, str]:
             or test('^/([^/]+)/home/([^/]+)(?:/(.+))?$',              Space.OTHER)
             or test('^/([^/]+)()(?:/(.+))?$',                         Space.OTHER)
             or (Space.OTHER, '', '', '')))  # (matches '/' and empty paths)
+
+
+def is_archived_datapackage_path(path: str) -> bool:
+    """Tests if a path is the top-level collection of an archived data package
+
+    :param path: Path to check
+
+    :returns: True if path refers to top-leve collection of data package. Else False.
+    """
+    return bool(re.match(r"^/[^/]+/home/vault-[^/]+/[^/]+\[\d+\]$", path))


### PR DESCRIPTION
Fix notifications job for exceeding the retention time of archived data packages. The function now processes only top-level collections of archived data packages. This resolves issues where the job will send notifications to users for other collections (e.g. for archived data packages that are already in the trash).