### PR TITLE
YDA-6549 fix for bug with dismissing notifications

### DIFF
--- a/uuGroupPolicies.r
+++ b/uuGroupPolicies.r
@@ -434,7 +434,7 @@ uuUserPreSudoObjMetaRemove(*objName, *objType, *wildcards, *attribute, *value, *
 
     if (*objType == "-u") {
         uuGetUserType(*objName, *targetUserType);
-        if (*targetUserType == "rodsuser") {
+        if (*targetUserType == "rodsuser" || *targetUserType == "rodsadmin") {
             if (*unit != "") {
                 # We do not use / allow the unit field here.
                 fail;


### PR DESCRIPTION
This fixes a bug where rodsadmin users were unable to dismiss notifications in the portal. This was caused by a policy change in YDA-5813 which removed policy logic that allowed rodsadmin users to remove any user metadata.

This fix restores the ability of rodsadmin users to perform any metadata changes that regular users can perform, which also fixes the problem with dismissing notifications.