### PR TITLE
YDA-6573: fix data package submit policy

### DIFF
--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -10,6 +10,7 @@ import folder
 import meta
 import notifications
 import provenance
+from policies_utils import should_transition_submitted_to_accepted_immediately
 from util import *
 
 
@@ -146,7 +147,9 @@ def post_status_transition(ctx: rule.Context,
                 datamanager_name = '{}#{}'.format(*datamanager)
                 notifications.set(ctx, actor, datamanager_name, path, message)
         else:
-            # Set status to accepted for deposit groups or if research group has no datamanager.
+            datamanagers = []
+
+        if should_transition_submitted_to_accepted_immediately(path, datamanagers):
             folder.set_status(ctx, path, constants.research_package_state.ACCEPTED)
 
     elif status is constants.research_package_state.ACCEPTED:

--- a/policies_utils.py
+++ b/policies_utils.py
@@ -1,12 +1,36 @@
 """iRODS policy utility functions"""
 
-__copyright__ = 'Copyright (c) 2024, Utrecht University'
+__copyright__ = 'Copyright (c) 2024-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import ast
-from typing import Set
+from typing import List, Set, Tuple
 
+from util import pathutil
 from util.genquery_col_constants import *
+
+
+def should_transition_submitted_to_accepted_immediately(folder_path: str, datamanagers: List[Tuple[str, str]]) -> bool:
+    """Determines whether a folder that is submitted should be transitioned to
+       an "accepted" status immediately, without an approval step.
+
+       :param folder_path: path of folder to be submitted.
+       :param datamanagers: list of datamanagers
+
+       :returns: boolean value. True if folder should be transitioned
+                 to accepted status immediately, otherwise false.
+    """
+    space = pathutil.info(folder_path).space
+    if space is pathutil.Space.RESEARCH:
+        # Data manager approval is not needed if the category has no data managers
+        return len(datamanagers) == 0
+    elif space is pathutil.Space.DEPOSIT:
+        # No approval is needed for data packages in deposit space
+        return True
+    else:
+        # Yoda does not support submitting data packages outside research and deposit space.
+        # Do not accept.
+        return False
 
 
 def is_safe_genquery_inp(genquery_inp: object) -> bool:

--- a/unit-tests/test_policies.py
+++ b/unit-tests/test_policies.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 sys.path.append('..')
 
-from policies_utils import _is_safe_genquery_inp
+from policies_utils import _is_safe_genquery_inp, should_transition_submitted_to_accepted_immediately
 
 
 class PoliciesTest(TestCase):
@@ -97,3 +97,11 @@ class PoliciesTest(TestCase):
         selectInp = {641: 1}
         sqlCondInp = []
         self.assertFalse(_is_safe_genquery_inp(selectInp, sqlCondInp))
+
+    def test_should_transition_submitted_to_accepted_immediately(self):
+        self.assertTrue(should_transition_submitted_to_accepted_immediately("/tempZone/home/research-foo/datapackage", []))
+        self.assertFalse(should_transition_submitted_to_accepted_immediately("/tempZone/home/research-foo/datapackage", [("datamanager", "tempZone")]))
+        self.assertTrue(should_transition_submitted_to_accepted_immediately("/tempZone/home/deposit-foo/datapackage", []))
+        self.assertTrue(should_transition_submitted_to_accepted_immediately("/tempZone/home/deposit-foo/datapackage", [("any", "any")]))
+        self.assertFalse(should_transition_submitted_to_accepted_immediately("/tempZone/home/not-deposit-or-research/datapackage", []))
+        self.assertFalse(should_transition_submitted_to_accepted_immediately("/tempZone/home/not-deposit-or-research/datapackage", [("any", "any")]))


### PR DESCRIPTION
Fix issue where data package in group with no data managers was not automatically accepted due to a
regression in the policy changes in YDA-6528.

Also extract policy logic to separate function and add test coverage to reduce risks of related regressions.