### PR TITLE
YDA-6667: fix MSI_OPERATION_NOT_ALLOWED error when targeting consumer with iBridges

### DIFF
--- a/replication.py
+++ b/replication.py
@@ -24,15 +24,11 @@ def replicate_asynchronously(ctx: rule.Context, path: str, source_resource: str,
     :param source_resource: Resource to be used as source
     :param target_resource: Resource to be used as destination
     """
-    zone = user.zone(ctx)
     replication_avu_name = constants.UUORGMETADATAPREFIX + "replication_scheduled"
     replication_avu_value = "{},{},{}".format(source_resource, target_resource, random.randint(1, 64))
 
     # Mark data object for batch replication by setting 'org_replication_scheduled' metadata.
     try:
-        # Give rods 'own' access so that they can remove the AVU.
-        msi.set_acl(ctx, "default", "own", "rods#{}".format(zone), path)
-
         # Check whether the object already has an AVU. If we try to add the AVU when it already
         # exists, we will catch the exception below, however the SQL error would still result in log
         # clutter. Checking beforehand reduces the log clutter, though such errors can still occur
@@ -130,6 +126,9 @@ def rule_replicate_batch(ctx: rule.Context, verbose: str, balance_id_min: int, b
 
             count += 1
             path = row[1] + "/" + row[2]
+
+            # Give rods 'own' access so that they can remove the AVU.
+            msi.set_acl(ctx, "default", "admin:own", "rods#{}".format(user.zone(ctx)), path)
 
             # Metadata value contains from_path, to_path and balance id for load balancing purposes.
             info = row[3].split(',')

--- a/revisions.py
+++ b/revisions.py
@@ -275,9 +275,6 @@ def resource_modified_post_revision(ctx: rule.Context, resource: str, zone: str,
 
     # Mark data object for batch revision by setting 'org_revision_scheduled' metadata.
     try:
-        # Give rods 'own' access so that they can remove the AVU.
-        msi.set_acl(ctx, "default", "own", "rods#{}".format(zone), path)
-
         # Check whether the object already has an AVU. If we try to add the AVU when it already
         # exists, we will catch the exception below, however the SQL error would still result in log
         # clutter. Checking beforehand reduces the log clutter, though such errors can still occur
@@ -406,6 +403,9 @@ def rule_revision_batch(ctx: rule.Context,
             # Perform scheduled revision creation for one data object.
             data_id = row[0]
             path    = row[1] + "/" + row[2]
+
+            # Give rods 'own' access so that they can remove the AVU.
+            msi.set_acl(ctx, "default", "admin:own", "rods#{}".format(user.zone(ctx)), path)
 
             # Metadata value contains resc and balance id for load balancing purposes.
             resc = get_resc(row)

--- a/tools/process-datarequest-temp-write-permission.r
+++ b/tools/process-datarequest-temp-write-permission.r
@@ -1,18 +1,25 @@
+#!/usr/bin/irule -r irods_rule_engine_plugin-irods_rule_language-instance -F
 processTempWritePermission() {
+    uuGetUserType("$userNameClient#$rodsZoneClient", *usertype);
 
-	if (*permission == "grant") {
-		msiSetACL("default", "write", *user, *path);
-        } else if (*permission == "grantread") {
-                msiSetACL("default", "read", *user, *path);
-        } else if (*permission == "own") {
-                msiSetACL("default", "own", *user, *path);
-	} else if (*permission == "revoke") {
-		msiSetACL("default", "null", *user, *path);
-	} else {
-		writeLine("stdout", "processTempWritePermission: invalid permission value");
-		*status = "InternalError";
-		*statusInfo = "";
-	}
+    if (*usertype != "rodsadmin") {
+        failmsg(-1, "This script needs to be run by a rodsadmin");
+    }
+
+    if (*permission == "grant") {
+        msiSetACL("default", "admin:write", *user, *path);
+    } else if (*permission == "grantread") {
+        msiSetACL("default", "admin:read", *user, *path);
+    } else if (*permission == "own") {
+        msiSetACL("default", "admin:own", *user, *path);
+    } else if (*permission == "revoke") {
+        msiSetACL("default", "admin:null", *user, *path);
+    } else {
+        writeLine("stdout", "processTempWritePermission: invalid permission value");
+        *status = "InternalError";
+        *statusInfo = "";
+    }
 }
+
 input *actor="", *path="", *permission="", *user=""
 output ruleExecOut


### PR DESCRIPTION
When targeting consumer with iBridges, an MSI_OPERATION_NOT_ALLOWED error is raised when msiSetACL is attempted on replication and revision. This PR fixes the issue by moving that call in the replication and revision batch job itself instead of earlier.