### PR TITLE
YDA-6616: move parsing of open access link to combiJson creation

### DIFF
--- a/json_landing_page.py
+++ b/json_landing_page.py
@@ -3,7 +3,6 @@
 __copyright__ = 'Copyright (c) 2019-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
-import urllib.parse
 from datetime import datetime
 from typing import Dict
 
@@ -198,7 +197,6 @@ def json_landing_page_create_json_landing_page(ctx: rule.Context,
     ############################################################################
     persistent_identifier_datapackage = json_data["System"]["Persistent_Identifier_Datapackage"]
     open_access_link = json_data["System"].get("Open_access_Link", "")
-    open_access_link = urllib.parse.quote(open_access_link, safe=":/=")
 
     license_uri = ""
     if no_active_embargo and license == 'Custom' and data_access_restriction.startswith('Open'):

--- a/publication.py
+++ b/publication.py
@@ -5,6 +5,7 @@ __license__   = 'GPLv3, see LICENSE'
 
 import json
 import re
+import urllib.parse
 from datetime import datetime
 from traceback import format_exc
 from typing import Dict, List, Tuple
@@ -99,6 +100,7 @@ def generate_combi_json(ctx: rule.Context, publication_config: Dict, publication
         subPath = vaultPackage[len(split_string) + vaultPackage.find(split_string):]
 
         openAccessLink = 'https://' + davrodsAnonymousVHost + "/" + subPath
+        openAccessLink = urllib.parse.quote(openAccessLink, safe=":/=")
 
     licenseUri = ""
     if "licenseUri" in publication_state:


### PR DESCRIPTION
This PR moves the URL parsing from the landing page creation to the combiJson creation, where the open_access_link is first generated. This solves the 422 HTTP response from DataCite, as the link was not parsed before sending it to DataCite.