### PR TITLE
Improve DataCite error handling

### DIFF
--- a/datacite.py
+++ b/datacite.py
@@ -25,7 +25,7 @@ def metadata_post(payload: Dict) -> int:
                              timeout=30,
                              verify=config.datacite_tls_verify)
 
-    return response.status_code
+    return response
 
 
 def metadata_put(doi: str, payload: str) -> int:
@@ -41,7 +41,7 @@ def metadata_put(doi: str, payload: str) -> int:
                             timeout=30,
                             verify=config.datacite_tls_verify)
 
-    return response.status_code
+    return response
 
 
 def metadata_get(doi: str) -> int:
@@ -56,10 +56,25 @@ def metadata_get(doi: str) -> int:
                             timeout=30,
                             verify=config.datacite_tls_verify)
 
-    return response.status_code
+    return response
 
 
 def generate_random_id(length: int) -> str:
     """Generate random ID for DOI."""
     characters = string.ascii_uppercase + string.digits
     return ''.join(random.choice(characters) for x in range(int(length)))
+
+
+def get_errors(response: dict) -> str:
+    """Get errors from DataCite response"""
+    error_msg = ''
+
+    if 'errors' in response:
+        errors = response['errors']
+        for error in errors:
+            if 'source' in error:
+                error_msg += "DataCite error from attribute \"" + error['source'] + "\": \"" + error['title'] + "\". "
+            else:
+                error_msg += "DataCite error: \"" + error['title'] + "\". "
+
+    return error_msg

--- a/datacite.py
+++ b/datacite.py
@@ -12,7 +12,7 @@ import requests
 from util import *
 
 
-def metadata_post(payload: Dict) -> int:
+def metadata_post(payload: Dict) -> requests.Response:
     """Register DOI metadata with DataCite."""
     url = "{}/dois".format(config.datacite_rest_api_url)
     auth = (config.datacite_username, config.datacite_password)
@@ -28,7 +28,7 @@ def metadata_post(payload: Dict) -> int:
     return response
 
 
-def metadata_put(doi: str, payload: str) -> int:
+def metadata_put(doi: str, payload: str) -> requests.Response:
     """Update metadata with DataCite."""
     url = "{}/dois/{}".format(config.datacite_rest_api_url, doi)
     auth = (config.datacite_username, config.datacite_password)
@@ -44,7 +44,7 @@ def metadata_put(doi: str, payload: str) -> int:
     return response
 
 
-def metadata_get(doi: str) -> int:
+def metadata_get(doi: str) -> requests.Response:
     """Check with DataCite if DOI is available."""
     url = "{}/dois/{}".format(config.datacite_rest_api_url, doi)
     auth = (config.datacite_username, config.datacite_password)

--- a/publication.py
+++ b/publication.py
@@ -381,22 +381,24 @@ def post_metadata_to_datacite(ctx: rule.Context, publication_state: Dict, doi: s
 
     try:
         if send_method == 'post':
-            httpCode = datacite.metadata_post(datacite_json)
+            response = datacite.metadata_post(datacite_json)
         else:
-            httpCode = datacite.metadata_put(doi, datacite_json)
+            response = datacite.metadata_put(doi, datacite_json)
 
-        if (send_method == 'post' and httpCode == 201) or (send_method == 'put' and httpCode == 200):
+        http_code = response.status_code
+
+        if (send_method == 'post' and http_code == 201) or (send_method == 'put' and http_code == 200):
             publication_state["dataCiteMetadataPosted"] = "yes"
-        elif httpCode in [401, 403, 500, 503, 504]:
+        elif http_code in [401, 403, 500, 503, 504]:
             # Unauthorized, Forbidden, Precondition failed, Internal Server Error
-            log.write(ctx, "post_metadata_to_datacite: httpCode " + str(httpCode) + " received. Will be retried later")
+            log.write(ctx, f"post_metadata_to_datacite: HTTP code {http_code} received. Operation will be retried later. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Retry"
         else:
-            log.write(ctx, "post_metadata_to_datacite: httpCode " + str(httpCode) + " received. Unrecoverable error.")
+            log.write(ctx, f"post_metadata_to_datacite: HTTP code {http_code} received. Unrecoverable error. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Unrecoverable"
     except ReadTimeout:
         # DataCite timeout.
-        log.write(ctx, "post_metadata_to_datacite: timeout received. Will be retried later")
+        log.write(ctx, "post_metadata_to_datacite: DataCite timeout received. Operation will be retried later.")
         publication_state["status"] = "Retry"
 
 
@@ -412,7 +414,7 @@ def post_draft_doi_to_datacite(ctx: rule.Context, publication_state: Dict) -> No
 
     try:
         # post the DOI only
-        httpCode = datacite.metadata_post({
+        response = datacite.metadata_post({
             'data': {
                 'type': 'dois',
                 'attributes': {
@@ -421,18 +423,20 @@ def post_draft_doi_to_datacite(ctx: rule.Context, publication_state: Dict) -> No
             }
         })
 
-        if httpCode == 201:
+        http_code = response.status_code
+
+        if http_code == 201:
             publication_state["dataCiteMetadataPosted"] = "no"
-        elif httpCode in [401, 403, 500, 503, 504]:
+        elif http_code in [401, 403, 500, 503, 504]:
             # Unauthorized, Forbidden, Precondition failed, Internal Server Error
-            log.write(ctx, "post_draft_doi_to_datacite: httpCode " + str(httpCode) + " received. Will be retried later")
+            log.write(ctx, f"post_draft_doi_to_datacite: HTTP code {http_code} received. Operation will be retried later. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Retry"
         else:
-            log.write(ctx, "post_draft_doi_to_datacite: httpCode " + str(httpCode) + " received. Unrecoverable error.")
+            log.write(ctx, f"post_draft_doi_to_datacite: HTTP code {http_code} received. Unrecoverable error. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Unrecoverable"
     except ReadTimeout:
         # DataCite timeout.
-        log.write(ctx, "post_draft_doi_to_datacite: timeout received. Will be retried later")
+        log.write(ctx, "post_draft_doi_to_datacite: DataCite timeout received. Operation will be retried later.")
         publication_state["status"] = "Retry"
 
 
@@ -446,24 +450,26 @@ def remove_metadata_from_datacite(ctx: rule.Context, publication_state: Dict, ty
     payload = json.dumps({"data": {"attributes": {"event": "hide"}}})
 
     try:
-        httpCode = datacite.metadata_put(publication_state[type_flag + "DOI"], payload)
+        response = datacite.metadata_put(publication_state[type_flag + "DOI"], payload)
 
-        if httpCode == 200:
+        http_code = response.status_code
+
+        if http_code == 200:
             publication_state["dataCiteMetadataPosted"] = "yes"
-        elif httpCode in [401, 403, 412, 500, 503, 504]:
+        elif http_code in [401, 403, 412, 500, 503, 504]:
             # Unauthorized, Forbidden, Precondition failed, Internal Server Error
-            log.write(ctx, "remove metadata from datacite: httpCode " + str(httpCode) + " received. Will be retried later")
+            log.write(ctx, f"remove_metadata_from_datacite: HTTP code {http_code} received. Operation will be retried later. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Retry"
-        elif httpCode == 404:
+        elif http_code == 404:
             # Invalid DOI
-            log.write(ctx, "remove metadata from datacite: 404 Not Found - Invalid DOI")
+            log.write(ctx, f"remove_metadata_from_datacite: HTTP code {http_code}. Invalid DOI. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Unrecoverable"
         else:
-            log.write(ctx, "remove metadata from datacite: httpCode " + str(httpCode) + " received. Unrecoverable error.")
+            log.write(ctx, f"remove_metadata_from datacite: HTTP code {http_code} received. Unrecoverable error. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Unrecoverable"
     except ReadTimeout:
         # DataCite timeout.
-        log.write(ctx, "remove_metadata_from_datacite: timeout received. Will be retried later")
+        log.write(ctx, "remove_metadata_from_datacite: DataCite timeout received. Operation will be retried later.")
         publication_state["status"] = "Retry"
 
 
@@ -477,23 +483,25 @@ def mint_doi(ctx: rule.Context, publication_state: Dict, type_flag: str) -> None
     payload = json.dumps({"data": {"attributes": {"url": publication_state["landingPageUrl"]}}})
 
     try:
-        httpCode = datacite.metadata_put(publication_state[type_flag + "DOI"], payload)
+        response = datacite.metadata_put(publication_state[type_flag + "DOI"], payload)
 
-        if httpCode == 200:  # 201:
+        http_code = response.status_code
+
+        if http_code == 200:  # 201:
             publication_state[type_flag + "DOIMinted"] = "yes"
-        elif httpCode in [401, 403, 412, 500, 503, 504]:
+        elif http_code in [401, 403, 412, 500, 503, 504]:
             # Unauthorized, Forbidden, Precondition failed, Internal Server Error
-            log.write(ctx, "mint_doi: httpCode " + str(httpCode) + " received. Could be retried later")
+            log.write(ctx, f"mint_doi: HTTP code {http_code} received. Operation could be retried later. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Retry"
-        elif httpCode == 400:
-            log.write(ctx, "mint_doi: 400 Bad Request - request body must be exactly two lines: DOI and URL; wrong domain, wrong prefix")
+        elif http_code == 400:
+            log.write(ctx, f"mint_doi: HTTP code {http_code} received. Request body must be exactly two lines: DOI and URL; wrong domain, wrong prefix. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Unrecoverable"
         else:
-            log.write(ctx, "mint_doi: httpCode " + str(httpCode) + " received. Unrecoverable error.")
+            log.write(ctx, f"mint_doi: HTTP code {http_code} received. Unrecoverable error. {datacite.get_errors(response.json())}")
             publication_state["status"] = "Unrecoverable"
     except ReadTimeout:
         # DataCite timeout.
-        log.write(ctx, "mint_doi: timeout received. Will be retried later")
+        log.write(ctx, "mint_doi: DataCite timeout received. Operation will be retried later.")
         publication_state["status"] = "Retry"
 
 
@@ -722,7 +730,9 @@ def check_doi_availability(ctx: rule.Context, publication_state: Dict, type_flag
     doi = publication_state[type_flag + "DOI"]
 
     try:
-        http_code = datacite.metadata_get(doi)
+        response = datacite.metadata_get(doi)
+
+        http_code = response.status_code
 
         if http_code == 404:
             publication_state[type_flag + "DOIAvailable"] = "yes"
@@ -735,7 +745,7 @@ def check_doi_availability(ctx: rule.Context, publication_state: Dict, type_flag
             publication_state["status"] = "Retry"
     except ReadTimeout:
         # DataCite timeout.
-        log.write(ctx, "check_doi_availability: timeout received. Will be retried later")
+        log.write(ctx, "check_doi_availability: DataCite timeout received. Operation will be retried later.")
         publication_state["status"] = "Retry"
 
 

--- a/publication_troubleshoot.py
+++ b/publication_troubleshoot.py
@@ -110,7 +110,8 @@ def check_one_datacite_doi_reg(ctx: rule.Context, data_package: str, doi_name: s
         log.write(ctx, "check_datacite_doi_registration: Error while trying to get {} - {}".format(doi_name, e), write_stdout)
         return False
 
-    status_code = datacite.metadata_get(doi)
+    response = datacite.metadata_get(doi)
+    status_code = response.status_code
     return status_code == 200
 
 


### PR DESCRIPTION
Following YDA-6616, I improved the error handling for DataCite to include DataCite errors in our logs for easier debugging in the future.