### PR TITLE
YDA-6781: improve schema validation messages

### DIFF
--- a/deposit.py
+++ b/deposit.py
@@ -13,8 +13,8 @@ from genquery import AS_DICT, Query
 
 import folder
 import groups
-import meta
 import vault
+from metadata_utils import is_json_metadata_valid
 from util import *
 
 __all__ = ['api_deposit_create',
@@ -169,7 +169,7 @@ def api_deposit_status(ctx: rule.Context, path: str) -> api.Result:
             data = True
 
     metadata = False
-    if data_object.exists(ctx, meta_path) and meta.is_json_metadata_valid(ctx, meta_path):
+    if data_object.exists(ctx, meta_path) and is_json_metadata_valid(ctx, meta_path):
         metadata = True
 
     return {"data": data, "metadata": metadata}

--- a/meta.py
+++ b/meta.py
@@ -12,13 +12,12 @@ from typing import Dict, List
 
 import genquery
 import irods_types
-import jsonschema
 
-import meta_form
 import provenance
 import publication
 import schema as schema_
 import vault
+from metadata_utils import get_json_metadata_errors, humanize_validation_error, is_json_metadata_valid
 from util import *
 
 __all__ = ['rule_meta_validate',
@@ -55,81 +54,6 @@ def metadata_set_schema_id(metadata: Dict, schema_id: str) -> None:
         ['rel',  'describedby'],
         ['href', schema_id]
     ])] + other_links
-
-
-def get_json_metadata_errors(ctx: rule.Context,
-                             metadata_path: str,
-                             metadata: Dict | None = None,
-                             schema: Dict | None = None,
-                             ignore_required: bool = False) -> List:
-    """
-    Validate JSON metadata, and return a list of errors, if any.
-
-    The path to the JSON object must be provided, so that the active schema path
-    can be derived. Optionally, a pre-parsed JSON object may be provided in
-    'metadata'.
-
-    The checked schema is, by default, the active schema for the given metadata path,
-    however it can be overridden by providing a parsed JSON schema as an argument.
-
-    This will throw exceptions on missing metadata / schema files and invalid
-    JSON formats.
-
-    :param ctx:             Combined type of a callback and rei struct
-    :param metadata_path:   Path to the JSON object
-    :param metadata:        Pre-parsed JSON object
-    :param schema:          Schema to check against
-    :param ignore_required: Ignore required fields
-
-    :returns: List of errors in JSON object
-    """
-    def transform_error(e):
-        """Turn a ValidationError into a data structure for the frontend."""
-        return {'message':     e.message,
-                'path':        list(e.path),
-                'schema_path': list(e.schema_path),
-                'validator':   e.validator}
-
-    if schema is None:
-        schema = schema_.get_active_schema(ctx, metadata_path)
-
-    if metadata is None:
-        metadata = jsonutil.read(ctx, metadata_path)
-
-    # Perform validation and filter errors.
-    validator = jsonschema.Draft201909Validator(schema)
-    errors = validator.iter_errors(metadata)
-
-    if ignore_required:
-        errors = filter(lambda e: e.validator not in ['required', 'dependencies'], errors)
-
-    return list(map(transform_error, errors))
-
-
-def is_json_metadata_valid(ctx: rule.Context,
-                           metadata_path: str,
-                           metadata: Dict | None = None,
-                           ignore_required: bool = False) -> bool:
-    """Check if json metadata contains no errors.
-
-    Argument 'metadata' may contain a preparsed JSON document, otherwise it
-    is loaded from the provided path.
-
-    :param ctx:             Combined type of a callback and rei struct
-    :param metadata_path:   Path to the JSON object
-    :param metadata:        Pre-parsed JSON object
-    :param ignore_required: Ignore required fields
-
-    :returns: Boolean indicating if JSON metadata is valid
-    """
-    try:
-        return len(get_json_metadata_errors(ctx,
-                                            metadata_path,
-                                            metadata=metadata,
-                                            ignore_required=ignore_required)) == 0
-    except error.UUError:
-        # File may be missing or not valid JSON.
-        return False
 
 
 def get_collection_metadata_path(ctx: rule.Context, coll: str) -> str | None:
@@ -752,7 +676,7 @@ def vault_metadata_matches_schema(ctx: rule.Context, coll_name: str, schema_cach
     error_list = get_json_metadata_errors(ctx, metadata_path, metadata=metadata, schema=schema_contents)
     match_schema = len(error_list) == 0
     if not match_schema:
-        errors_formatted = [meta_form.humanize_validation_error(e).encode('utf-8') for e in error_list]
+        errors_formatted = [humanize_validation_error(e).encode('utf-8') for e in error_list]
         log.write(ctx, "{}: metadata {} did not match schema {}: {}".format(report_name, metadata_path, schema_shortname, str(errors_formatted)), write_stdout)
         log.write(ctx, "vault_metadata_matches_schema: Metadata {} of data package {} did not match the schema {}. Error list: {}".format(metadata_path, coll_name, schema_shortname, str(errors_formatted)), write_stdout)
 

--- a/meta_form.py
+++ b/meta_form.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 __copyright__ = 'Copyright (c) 2019-2026, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
-import re
 from typing import Dict, List, Tuple
 
 import irods_types
@@ -15,6 +14,7 @@ import meta
 import schema as schema_
 import schema_transformation
 import vault
+from metadata_utils import get_json_metadata_errors, humanize_validation_error
 from util import *
 
 __all__ = ['api_meta_form_load',
@@ -69,35 +69,6 @@ def get_coll_lock_count(ctx: rule.Context, path: str, org_metadata: List | None 
         count += 1
 
     return count
-
-
-def humanize_validation_error(e: str) -> str:
-    """Transform a jsonschema validation error such that it is readable by humans.
-
-    :param e: a jsonschema.exceptions.ValidationError
-
-    :returns: a supposedly human-readable description of the error
-    """
-    # Error format: "Creator 1 -> Person Identifier 1 -> Name Identifier Scheme"
-
-    # Make array indices human-readable.
-    path_out = []
-    for _i, x in enumerate(e['path']):
-        if type(x) is int:
-            path_out[-1] = '{} {}'.format(path_out[-1], x + 1)
-        else:
-            path_out += [x.replace('_', ' ')]
-
-    # Get the names of disallowed extra fields.
-    # (the jsonschema library isn't of much help here - we must extract it from the message)
-    if e['validator'] == 'additionalProperties' and len(path_out) == 0:
-        m = re.search('[\'\"]([^\"\']+)[\'\"] was unexpected', e['message'])
-        if m:
-            return 'This extra field is not allowed: ' + m.group(1)
-        else:
-            return 'Extra fields are not allowed'
-    else:
-        return 'This field contains an error: ' + ' -> '.join(path_out)
 
 
 def load(ctx: rule.Context, coll: str) -> api.Result:
@@ -191,11 +162,11 @@ def load(ctx: rule.Context, coll: str) -> api.Result:
                 try:
                     current_schema = schema_.get_schema_by_id(ctx, meta_path, current_schema_id)
                     errors = [humanize_validation_error(x) for x
-                              in meta.get_json_metadata_errors(ctx,
-                                                               meta_path,
-                                                               metadata=metadata,
-                                                               schema=current_schema,
-                                                               ignore_required=True)]
+                              in get_json_metadata_errors(ctx,
+                                                          meta_path,
+                                                          metadata=metadata,
+                                                          schema=current_schema,
+                                                          ignore_required=True)]
                     if errors:
                         return api.Error('validation', 'The metadata file is not compliant with the schema.',
                                          data={'errors': errors})
@@ -213,11 +184,11 @@ def load(ctx: rule.Context, coll: str) -> api.Result:
             if current_schema_id == schema['$id']:
                 # Metadata matches active schema, see if it validates.
                 errors = [humanize_validation_error(x) for x
-                          in meta.get_json_metadata_errors(ctx,
-                                                           meta_path,
-                                                           metadata=metadata,
-                                                           schema=schema,
-                                                           ignore_required=True)]
+                          in get_json_metadata_errors(ctx,
+                                                      meta_path,
+                                                      metadata=metadata,
+                                                      schema=schema,
+                                                      ignore_required=True)]
                 if errors:
                     return api.Error('validation', 'The metadata file is not compliant with the schema.',
                                      data={'errors': errors})
@@ -261,11 +232,11 @@ def load(ctx: rule.Context, coll: str) -> api.Result:
         if current_schema_id == schema['$id']:
             # Metadata matches active schema, see if it validates.
             errors = [humanize_validation_error(x) for x
-                      in meta.get_json_metadata_errors(ctx,
-                                                       meta_path,
-                                                       metadata=metadata,
-                                                       schema=schema,
-                                                       ignore_required=True)]
+                      in get_json_metadata_errors(ctx,
+                                                  meta_path,
+                                                  metadata=metadata,
+                                                  schema=schema,
+                                                  ignore_required=True)]
             if errors:
                 return api.Error('validation', 'The metadata file is not compliant with the schema.',
                                  data={'errors': errors})
@@ -325,7 +296,7 @@ def save(ctx: rule.Context, coll: str, metadata: Dict) -> api.Result:
     meta.metadata_set_schema_id(metadata, schema_.get_active_schema_id(ctx, json_path))
 
     # Validate JSON metadata.
-    errors = meta.get_json_metadata_errors(ctx, json_path, metadata, ignore_required=not is_vault)
+    errors = get_json_metadata_errors(ctx, json_path, metadata, ignore_required=not is_vault)
 
     if len(errors) > 0:
         return api.Error('validation', 'Metadata validation failed', data={'errors': errors})

--- a/metadata_utils.py
+++ b/metadata_utils.py
@@ -1,0 +1,133 @@
+"""Utility functions for metadata management."""
+
+__copyright__ = 'Copyright (c) 2019-2026, Utrecht University'
+__license__   = 'GPLv3, see LICENSE'
+
+import re
+import sys
+from typing import Dict, List, Union
+
+import jsonschema
+
+from util import error, rule
+
+if 'unittest' not in sys.modules:
+    import schema as schema_
+    from util import jsonutil
+
+
+def get_json_metadata_errors(ctx: rule.Context,
+                             metadata_path: str,
+                             metadata: Union[Dict, None] = None,
+                             schema: Union[Dict, None] = None,
+                             ignore_required: bool = False) -> List:
+    """
+    Validate JSON metadata, and return a list of errors, if any.
+
+    The path to the JSON object must be provided, so that the active schema path
+    can be derived. Optionally, a pre-parsed JSON object may be provided in
+    'metadata'.
+
+    The checked schema is, by default, the active schema for the given metadata path,
+    however it can be overridden by providing a parsed JSON schema as an argument.
+
+    This will throw exceptions on missing metadata / schema files and invalid
+    JSON formats.
+
+    :param ctx:             Combined type of a callback and rei struct
+    :param metadata_path:   Path to the JSON object
+    :param metadata:        Pre-parsed JSON object
+    :param schema:          Schema to check against
+    :param ignore_required: Ignore required fields
+
+    :returns: List of errors in JSON object
+    """
+    def transform_error(e):
+        """Turn a ValidationError into a data structure for the frontend."""
+        return {'message':     e.message,
+                'path':        list(e.path),
+                'schema_path': list(e.schema_path),
+                'validator':   e.validator}
+
+    if schema is None:
+        schema = schema_.get_active_schema(ctx, metadata_path)
+
+    if metadata is None:
+        metadata = jsonutil.read(ctx, metadata_path)
+
+    # Perform validation and filter errors.
+    validator = jsonschema.Draft201909Validator(schema)
+    errors = list(validator.iter_errors(metadata))
+
+    if ignore_required:
+        errors = list(filter(lambda e: e.validator not in ['required', 'dependencies'], errors))
+
+    return list(map(transform_error, errors))
+
+
+def is_json_metadata_valid(ctx: rule.Context,
+                           metadata_path: str,
+                           metadata: Union[Dict, None] = None,
+                           ignore_required: bool = False) -> bool:
+    """Check if json metadata contains no errors.
+
+    Argument 'metadata' may contain a preparsed JSON document, otherwise it
+    is loaded from the provided path.
+
+    :param ctx:             Combined type of a callback and rei struct
+    :param metadata_path:   Path to the JSON object
+    :param metadata:        Pre-parsed JSON object
+    :param ignore_required: Ignore required fields
+
+    :returns: Boolean indicating if JSON metadata is valid
+    """
+    try:
+        return len(get_json_metadata_errors(ctx,
+                                            metadata_path,
+                                            metadata=metadata,
+                                            ignore_required=ignore_required)) == 0
+    except error.UUError:
+        # File may be missing or not valid JSON.
+        return False
+
+
+def humanize_validation_error(e: dict) -> str:
+    """Transform a jsonschema validation error such that it is readable by humans.
+
+    :param e: a jsonschema.exceptions.ValidationError
+
+    :returns: a supposedly human-readable description of the error
+    """
+    # Error format: "Creator 1 -> Person Identifier 1 -> Name Identifier Scheme"
+
+    # Make array indices human-readable.
+    path_out = []
+    for _i, x in enumerate(e['path']):
+        if isinstance(x, int):
+            path_out[-1] = '{} {}'.format(path_out[-1], x + 1)
+        else:
+            path_out += [x.replace('_', ' ')]
+
+    # Get the names of disallowed extra fields.
+    # (the jsonschema library isn't of much help here - we must extract it from the message)
+    if e['validator'] in ['additionalProperties', 'unevaluatedProperties'] and len(path_out) == 0:
+        m_single = re.search(r'[\'\"]([^\"\']+)[\'\"] was unexpected', e['message'])
+        m_multiple = re.search(r'\((([\'\"]([^\"\']+)[\'\"], )+([\'\"]([^\"\']+)[\'\"])) were unexpected\)', e['message'])
+        if m_single:
+            return 'This extra field is not allowed: ' + m_single.group(1)
+        elif m_multiple:
+            return 'These extra fields are not allowed: ' + m_multiple.group(1)
+        else:
+            return 'Extra fields are not allowed'
+    elif e['validator'] == 'required':
+        m = re.search("[\'\"]([^\"\']+)[\'\"] is a required property", e['message'])
+        if m:
+            return 'This field is missing: ' + m.group(1)
+        else:
+            return 'There are missing fields'
+    elif len(path_out) > 0:
+        return 'This field contains an error: ' + ' -> '.join(path_out)
+    else:
+        # If we don't have a standard message or at least a specific path,
+        # fall back to the message returned by the validator.
+        return 'Validation error: ' + e['message']

--- a/policies_datapackage_status.py
+++ b/policies_datapackage_status.py
@@ -9,6 +9,7 @@ import meta
 import notifications
 import provenance
 import vault
+from metadata_utils import is_json_metadata_valid
 from util import *
 
 
@@ -36,7 +37,7 @@ def can_transition_datapackage_status(ctx: rule.Context,
         if meta_path is None:
             return policy.fail('Metadata missing, unable to submit this data package for publication.')
 
-        if not meta.is_json_metadata_valid(ctx, meta_path):
+        if not is_json_metadata_valid(ctx, meta_path):
             return policy.fail('Metadata is incomplete or invalid, please open the metadata form for more information')
 
     return policy.succeed()

--- a/policies_folder_status.py
+++ b/policies_folder_status.py
@@ -10,6 +10,7 @@ import folder
 import meta
 import notifications
 import provenance
+from metadata_utils import is_json_metadata_valid
 from policies_utils import should_transition_submitted_to_accepted_immediately
 from util import *
 
@@ -79,7 +80,7 @@ def can_transition_folder_status(ctx: rule.Context,
         if not data_object.exists(ctx, meta_path):
             return policy.fail('Metadata missing, unable to submit this folder')
 
-        if not meta.is_json_metadata_valid(ctx, meta_path):
+        if not is_json_metadata_valid(ctx, meta_path):
             return policy.fail('Metadata is incomplete or invalid, please open the metadata form for more information')
 
     elif status_to in [constants.research_package_state.ACCEPTED,

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ strictness=short
 docstring_style=sphinx
 max-line-length=127
 exclude=__init__.py,tools,tests/env/
-application-import-names=arb,avu,conftest,util,api,config,constants,data_access_token,datacite,datarequest,data_object,epic,error,folder,groups,groups_import,json_datacite,json_landing_page,jsonutil,log,mail,meta,meta_form,msi,notifications,research,schema,schema_transformation,schema_transformations,settings,stats,pathutil,provenance,policies_intake,policies_datamanager,policies_datapackage_status,policies_folder_status,policies_datarequest_status,publication,query,replication,revisions,revision_strategies,revision_utils,rule,user,vault,sram,arb_data_manager,cached_data_manager,resources,yoda_names,policies_utils,vault_utils,measure_coverage
+application-import-names=arb,avu,conftest,util,api,config,constants,data_access_token,datacite,datarequest,data_object,epic,error,folder,groups,groups_import,json_datacite,json_landing_page,jsonutil,log,mail,meta,meta_form,metadata_utils,msi,notifications,research,schema,schema_transformation,schema_transformations,settings,stats,pathutil,provenance,policies_intake,policies_datamanager,policies_datapackage_status,policies_folder_status,policies_datarequest_status,publication,query,replication,revisions,revision_strategies,revision_utils,rule,user,vault,sram,arb_data_manager,cached_data_manager,resources,yoda_names,policies_utils,vault_utils,measure_coverage
 
 [mypy]
 exclude = tools|unit-tests

--- a/unit-tests/test_metadata_utils.py
+++ b/unit-tests/test_metadata_utils.py
@@ -1,0 +1,180 @@
+"""Unit tests for metadata functions"""
+
+__copyright__ = 'Copyright (c) 2023-2026, Utrecht University'
+__license__   = 'GPLv3, see LICENSE'
+
+import json
+import sys
+from unittest import TestCase
+
+sys.path.append('../util')
+
+from metadata_utils import get_json_metadata_errors, humanize_validation_error
+
+
+class MetadataUtilsTest(TestCase):
+    SAMPLE_SCHEMA = """
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "author": {
+      "type": "string"
+    },
+    "medium": {
+     "type": "string",
+     "enum": ["book", "film"]
+    }
+  },
+  "required": ["title", "author"],
+  "additionalProperties": false
+}
+   """
+    SAMPLE_SCHEMA_UNEVALUATED_PROPERTIES = """
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "author": {
+      "type": "string"
+    },
+    "medium": {
+     "type": "string",
+     "enum": ["book", "film"]
+    }
+  },
+  "required": ["title", "author"],
+  "unevaluatedProperties": false
+}
+   """
+
+    def test_get_json_metadata_errors_correct(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps", "author": "John Buchan" }'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          False
+                                          )
+        self.assertEqual(errors, [])
+
+    def test_get_json_metadata_errors_missing_element(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps" }'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          False
+                                          )
+        self.assertEqual(errors, [
+            {'message': "'author' is a required property",
+             'path': [],
+             'schema_path': ['required'],
+             'validator': 'required'}
+        ])
+        self.assertEqual(humanize_validation_error(errors[0]),
+                         'This field is missing: author')
+
+    def test_get_json_metadata_errors_missing_element_ignore_required(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps" }'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          True
+                                          )
+        self.assertEqual(errors, [])
+
+    def test_get_json_metadata_errors_extra_element(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps", "author": "John Buchan", "year": 1915}'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          False
+                                          )
+        self.assertEqual(errors, [
+            {'message': "Additional properties are not allowed ('year' was unexpected)",
+             'path': [],
+             'schema_path': ['additionalProperties'],
+             'validator': 'additionalProperties'}
+        ])
+        self.assertEqual(humanize_validation_error(errors[0]),
+                         'This extra field is not allowed: year')
+
+    def test_get_json_metadata_errors_extra_element_unevaluated(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps", "author": "John Buchan", "year": 1915}'),
+                                          json.loads(self.SAMPLE_SCHEMA_UNEVALUATED_PROPERTIES),
+                                          False
+                                          )
+        self.assertEqual(errors, [
+            {'message': "Unevaluated properties are not allowed ('year' was unexpected)",
+             'path': [],
+             'schema_path': ['unevaluatedProperties'],
+             'validator': 'unevaluatedProperties'}
+        ])
+        self.assertEqual(humanize_validation_error(errors[0]),
+                         'This extra field is not allowed: year')
+
+    def test_get_json_metadata_errors_extra_elements(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps", "author": "John Buchan", "year": 1915, "protagonist": "Richard Hannay"}'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          False
+                                          )
+        self.assertEqual(errors, [
+            {'message': "Additional properties are not allowed ('protagonist', 'year' were unexpected)",
+             'path': [],
+             'schema_path': ['additionalProperties'],
+             'validator': 'additionalProperties'}
+        ])
+        self.assertEqual(humanize_validation_error(errors[0]),
+                         "These extra fields are not allowed: 'protagonist', 'year'")
+
+    def test_get_json_metadata_errors_wrong_element_name(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps", "writer": "John Buchan" }'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          False
+                                          )
+        self.assertEqual(errors, [
+            {'message': "'author' is a required property",
+             'path': [],
+             'schema_path': ['required'],
+             'validator': 'required'},
+            {'message': "Additional properties are not allowed ('writer' was unexpected)",
+             'path': [],
+             'schema_path': ['additionalProperties'],
+             'validator': 'additionalProperties'},
+        ])
+
+    def test_get_json_metadata_errors_good_enum(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps", "author": "John Buchan", "medium": "book" }'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          False
+                                          )
+        self.assertEqual(errors, [])
+
+    def test_get_json_metadata_errors_bad_enum(self):
+        errors = get_json_metadata_errors(None,
+                                          '',
+                                          json.loads('{ "title": "The Thirty-Nine Steps", "author": "John Buchan", "medium": "novel" }'),
+                                          json.loads(self.SAMPLE_SCHEMA),
+                                          False
+                                          )
+        self.assertEqual(errors, [
+            {'message': "'novel' is not one of ['book', 'film']",
+             'path': ['medium'],
+             'schema_path': ['properties', 'medium', 'enum'],
+             'validator': 'enum'}
+        ])
+        self.assertEqual(humanize_validation_error(errors[0]),
+                         'This field contains an error: medium')

--- a/unit-tests/unit_tests.py
+++ b/unit-tests/unit_tests.py
@@ -4,6 +4,7 @@ __license__   = 'GPLv3, see LICENSE'
 from unittest import makeSuite, TestSuite
 
 from test_group_import import GroupImportTest
+from test_metadata_utils import MetadataUtilsTest
 from test_policies import PoliciesTest
 from test_revisions import RevisionTest
 from test_schema_transformations import CorrectifyIsniTest, CorrectifyOrcidTest, CorrectifyResearcherIDTest, CorrectifyScopusTest, MergeGeoKeywordsTest, RenameRelatedDatapackageTest
@@ -23,6 +24,7 @@ def suite():
     test_suite.addTest(makeSuite(MergeGeoKeywordsTest))
     test_suite.addTest(makeSuite(RenameRelatedDatapackageTest))
     test_suite.addTest(makeSuite(GroupImportTest))
+    test_suite.addTest(makeSuite(MetadataUtilsTest))
     test_suite.addTest(makeSuite(PoliciesTest))
     test_suite.addTest(makeSuite(RevisionTest))
     test_suite.addTest(makeSuite(SchemaUtilsTest))


### PR DESCRIPTION
Ensure that schema validation human-readable messages include specific information in case of multiple undefined attributes or in case of a non-standard error message.

As a part of this change, the validation functions were refactored so that these functions could be covered by unit tests.