### PR TITLE
YDA-6777: add baseDOIMinted as expected AVU for first version of publication

### DIFF
--- a/unit-tests/test_util_misc.py
+++ b/unit-tests/test_util_misc.py
@@ -71,6 +71,7 @@ avs_success_data_package_multiversion_first = {
     "org_publication_anonymousAccess": "yes",
     "org_publication_approval_actor": "datamanager#tempZone",
     "org_publication_baseDOI": "10.00012/UU01-X0GU3S",
+    "org_publication_baseDOIMinted": "yes",
     "org_publication_baseRandomId": "X0GU3S",
     "org_publication_combiJsonPath": "/tempZone/yoda/publication/T8D8QU-combi.json",
     "org_publication_dataCiteJsonPath": "/tempZone/yoda/publication/T8D8QU-dataCite.json",

--- a/util/misc.py
+++ b/util/misc.py
@@ -49,13 +49,12 @@ def check_data_package_system_avus(extracted_avus: Dict) -> Dict:
 
     # Define additional set of AVUs with more than one version of publication
     avu_names_version_suffix = {
-        'previous_version', 'baseDOI', 'baseRandomId',
-        'baseDOIMinted'
+        'baseDOI', 'baseDOIMinted', 'baseRandomId', 'previous_version'
     }
 
     # Define additional set of AVUs expected for the first version of a publication, when there are multiple versions
     avu_names_first_version_suffix = {
-        'baseRandomId', 'baseDOI', 'next_version'
+        'baseDOI', 'baseDOIMinted', 'baseRandomId', 'next_version'
     }
 
     # for the second version, all we need is next_version in addition to avu_names_version_suffix


### PR DESCRIPTION
This PR adds the baseDOIMinted to the list of expected AVUs for the first version of a publication. This also works for the troubleshooting tool.