### PR TITLE
YDA-6776: add ability to run transform publications tool on a single collection

### DIFF
--- a/tools/transform-existing-publications.r
+++ b/tools/transform-existing-publications.r
@@ -7,10 +7,11 @@
 #                       and add prefix version to DOIAvailable and DOI Minted variables.
 # modify_basedoiminted: If True, this script will copy baseDOIMinted attribute value from new version
 #                       to previous version of data package.
-# 
+# package:              If a data package is specified, this script will perform the above operations 
+#                       only on data packages related to it. If none is specified, operations will
+#                       be performed on all data packages in the zone where the script is executed from.
 #
-# irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/transform-existing-publications.r 
-# '*modify_prefix=False' '*modify_basedoiminted=True'
+# irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/transform-existing-publications.r '*modify_prefix=False' '*modify_basedoiminted=True' '*package=/path/to/collection'
 # 
 import subprocess
 import genquery
@@ -50,7 +51,7 @@ def prefix_transformation(zone, callback):
         subprocess.call(["imeta", "mod", "-C", row[0], row[1], row[2], "n:{}".format(attr_name), "v:{}".format(row[2])])
 
 
-def datapackages_and_versions(zone, callback):
+def datapackages_and_versions(zone, coll_name, callback):
     """Get published data packages and their newer version stored in metadata. 
 
     :param zone:     iRODS zone
@@ -59,12 +60,20 @@ def datapackages_and_versions(zone, callback):
     :returns: List of relevant data packages
     """
     package_list = []
-    
-    datapackages = genquery.row_iterator(
-        "COLL_NAME, META_COLL_ATTR_VALUE",
-        "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME = '{}publication_next_version'".format(zone, constants.UUORGMETADATAPREFIX),
-        genquery.AS_LIST,
-        callback) 
+
+    # If a collection was specified, query data packages related to it; if not, query data packages in the whole zone
+    if coll_name == '':
+        datapackages = genquery.row_iterator(
+            "COLL_NAME, META_COLL_ATTR_VALUE",
+            "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME = '{}publication_next_version'".format(zone, constants.UUORGMETADATAPREFIX),
+            genquery.AS_LIST,
+            callback)
+    else: 
+        datapackages = genquery.row_iterator(
+            "COLL_NAME, META_COLL_ATTR_VALUE",
+            "COLL_NAME = '{}' AND META_COLL_ATTR_NAME = '{}publication_next_version'".format(coll_name, constants.UUORGMETADATAPREFIX),
+            genquery.AS_LIST,
+            callback)
 
     # Create list with placeholders for baseDOIMinted values
     for row in datapackages:
@@ -129,19 +138,30 @@ def basedoiminted_correction(zone, list, callback):
 def main(rule_args, callback, rei):
     modify_prefix = global_vars["*modify_prefix"]
     modify_basedoiminted = global_vars["*modify_basedoiminted"]
+    package = global_vars["*package"]
 
+    datapackages = []
     zone = session_vars.get_map(rei)['client_user']['irods_zone']
 
-    if modify_prefix == 'True':
-        try:
-            prefix_transformation(zone, callback)
-        except Exception as e:
-            callback.writeLine("stdout", "prefix_transformation: Error encountered while modifying prefix for existing publications - {}".format(e))
+    # Verify existence of a data package if one is specified
+    if package != '' and len(list(genquery.Query(callback, "COLL_ID", f"COLL_NAME = '{package}'"))) <= 0:
+        callback.writeLine("stdout", "Specified collection was not found.")
+    else:
+        datapackages = datapackages_and_versions(zone, package, callback)
 
-    if modify_basedoiminted == 'True':
-        datapackages = datapackages_and_versions(zone, callback)
-        basedoiminted_correction(zone, datapackages, callback)
+    # If data packages were found, transform AVUs
+    if datapackages:
+        if modify_prefix == 'True':
+            try:
+                prefix_transformation(zone, callback)
+            except Exception as e:
+                callback.writeLine("stdout", "prefix_transformation: Error encountered while modifying prefix for existing publications - {}".format(e))
+
+        if modify_basedoiminted == 'True':
+            basedoiminted_correction(zone, datapackages, callback)
+    else:
+        callback.writeLine("stdout", "No data packages were found.")
 
 
-INPUT *modify_prefix=False, *modify_basedoiminted=True
+INPUT *modify_prefix=False, *modify_basedoiminted=True, *package=
 OUTPUT ruleExecOut

--- a/tools/transform-existing-publications.r
+++ b/tools/transform-existing-publications.r
@@ -7,16 +7,17 @@
 #                       and add prefix version to DOIAvailable and DOI Minted variables.
 # modify_basedoiminted: If True, this script will copy baseDOIMinted attribute value from new version
 #                       to previous version of data package.
-# package:              If a data package is specified, this script will perform the above operations 
+# package:              If a data package is specified, this script will perform the above operations
 #                       only on data packages related to it. If none is specified, operations will
 #                       be performed on all data packages in the zone where the script is executed from.
 #
 # irule -r irods_rule_engine_plugin-python-instance -F /etc/irods/yoda-ruleset/tools/transform-existing-publications.r '*modify_prefix=False' '*modify_basedoiminted=True' '*package=/path/to/collection'
-# 
+#
 import subprocess
 import genquery
 import session_vars
 import constants
+
 
 def prefix_transformation(zone, callback):
     """Replace 'yoda' prefix with 'version'. Add 'version' prefix to
@@ -32,14 +33,14 @@ def prefix_transformation(zone, callback):
         "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
         "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME LIKE '{}publication_yoda%'".format(zone, org_prefix),
         genquery.AS_TUPLE,
-        callback) 
+        callback)
 
     # Add 'version' prefix to DOIAvailable and DOIMinted AVUs
     add_prefix = genquery.row_iterator(
         "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
         "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME in ('{p}publication_DOIAvailable', '{p}publication_DOIMinted')".format(zone, p=org_prefix),
         genquery.AS_TUPLE,
-        callback) 
+        callback)
 
     for row in change_prefix:
         callback.writeLine("stdout", "Changing 'yoda' prefix to 'version' for collection: {}".format(row[0]))
@@ -52,10 +53,11 @@ def prefix_transformation(zone, callback):
 
 
 def datapackages_and_versions(zone, coll_name, callback):
-    """Get published data packages and their newer version stored in metadata. 
+    """Get published data packages and their newer version stored in metadata.
 
-    :param zone:     iRODS zone
-    :param callback: iRODS callback
+    :param zone:        iRODS zone
+    :param coll_name:   iRODS collection name (optional)
+    :param callback:    iRODS callback
 
     :returns: List of relevant data packages
     """
@@ -68,7 +70,7 @@ def datapackages_and_versions(zone, coll_name, callback):
             "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME = '{}publication_next_version'".format(zone, constants.UUORGMETADATAPREFIX),
             genquery.AS_LIST,
             callback)
-    else: 
+    else:
         datapackages = genquery.row_iterator(
             "COLL_NAME, META_COLL_ATTR_VALUE",
             "COLL_NAME = '{}' AND META_COLL_ATTR_NAME = '{}publication_next_version'".format(coll_name, constants.UUORGMETADATAPREFIX),
@@ -106,8 +108,8 @@ def basedoiminted_value(zone, package, callback):
 
 
 def basedoiminted_correction(zone, list, callback):
-    """ Get the baseDOIMinted attribute and value from previous and new version 
-    of data package. If the previous version does not have baseDOIMinted, get the 
+    """ Get the baseDOIMinted attribute and value from previous and new version
+    of data package. If the previous version does not have baseDOIMinted, get the
     value from new version and add it to metadata.
 
     :param zone:     iRODS zone
@@ -128,7 +130,7 @@ def basedoiminted_correction(zone, list, callback):
 
         if row[1] == '':
             callback.writeLine("stdout", "Modify baseDOIMinted attribute for collection: {}".format(row[0]))
-            try:                
+            try:
                 subprocess.call(["imeta", "add", "-C", row[0], "{}publication_baseDOIMinted".format(constants.UUORGMETADATAPREFIX), row[3]])
                 transformed_data_packages.append(row[0])
             except Exception as e:

--- a/tools/transform-existing-publications.r
+++ b/tools/transform-existing-publications.r
@@ -23,8 +23,9 @@ def prefix_transformation(zone, coll_name, callback):
     """Replace 'yoda' prefix with 'version'. Add 'version' prefix to
     DOIAvailable and DOIMinted AVUs.
 
-    :param zone:          iRODS zone
-    :param callback:      iRODS callback
+    :param zone:        iRODS zone
+    :param coll_name:   iRODS collection name (optional)
+    :param callback:    iRODS callback
     """
     # Check if specified package (or any package in current zone, if none is specified) still has 'yoda' prefixes or DOIAvailable / DOIMinted AVUs
     if coll_name == '':

--- a/tools/transform-existing-publications.r
+++ b/tools/transform-existing-publications.r
@@ -19,33 +19,45 @@ import session_vars
 import constants
 
 
-def prefix_transformation(zone, callback):
+def prefix_transformation(zone, coll_name, callback):
     """Replace 'yoda' prefix with 'version'. Add 'version' prefix to
     DOIAvailable and DOIMinted AVUs.
 
     :param zone:          iRODS zone
     :param callback:      iRODS callback
     """
-    org_prefix = constants.UUORGMETADATAPREFIX
+    # Check if specified package (or any package in current zone, if none is specified) still has 'yoda' prefixes or DOIAvailable / DOIMinted AVUs
+    if coll_name == '':
+        change_prefix = genquery.row_iterator(
+            "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
+            "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME LIKE '{}publication_yoda%'".format(zone, constants.UUORGMETADATAPREFIX),
+            genquery.AS_TUPLE,
+            callback)
 
-    # Changing yoda prefix -> version
-    change_prefix = genquery.row_iterator(
-        "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
-        "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME LIKE '{}publication_yoda%'".format(zone, org_prefix),
-        genquery.AS_TUPLE,
-        callback)
+        add_prefix = genquery.row_iterator(
+            "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
+            "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME in ('{p}publication_DOIAvailable', '{p}publication_DOIMinted')".format(zone, p=constants.UUORGMETADATAPREFIX),
+            genquery.AS_TUPLE,
+            callback)
+    else:
+        change_prefix = genquery.row_iterator(
+            "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
+            "COLL_NAME = '{}' AND META_COLL_ATTR_NAME LIKE '{}publication_yoda%'".format(coll_name, constants.UUORGMETADATAPREFIX),
+            genquery.AS_TUPLE,
+            callback)
 
-    # Add 'version' prefix to DOIAvailable and DOIMinted AVUs
-    add_prefix = genquery.row_iterator(
-        "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
-        "COLL_ZONE_NAME = '{}' AND META_COLL_ATTR_NAME in ('{p}publication_DOIAvailable', '{p}publication_DOIMinted')".format(zone, p=org_prefix),
-        genquery.AS_TUPLE,
-        callback)
+        add_prefix = genquery.row_iterator(
+            "COLL_NAME, META_COLL_ATTR_NAME, META_COLL_ATTR_VALUE",
+            "COLL_NAME = '{}' AND META_COLL_ATTR_NAME in ('{p}publication_DOIAvailable', '{p}publication_DOIMinted')".format(coll_name, p=constants.UUORGMETADATAPREFIX),
+            genquery.AS_TUPLE,
+            callback)
 
+    # Replace 'yoda' prefix with 'version'
     for row in change_prefix:
         callback.writeLine("stdout", "Changing 'yoda' prefix to 'version' for collection: {}".format(row[0]))
         subprocess.call(["imeta", "mod", "-C", row[0], row[1], row[2], "n:{}".format(row[1].replace("yoda", "version")), "v:{}".format(row[2])])
 
+    # Add 'version' prefix to DOIAvailable and DOIMinted AVUs
     for row in add_prefix:
         callback.writeLine("stdout", "Adding 'version' prefix to DOIAvailable and DOIMinted AVUs for collection: {}".format(row[0]))
         attr_name = row[1].rsplit('_', 1)[0] + "_version" + row[1].split('_')[-1]
@@ -63,7 +75,7 @@ def datapackages_and_versions(zone, coll_name, callback):
     """
     package_list = []
 
-    # If a collection was specified, query data packages related to it; if not, query data packages in the whole zone
+    # If a collection is specified, query its newer version (if exists); if not, query all data packages with newer versions in current zone
     if coll_name == '':
         datapackages = genquery.row_iterator(
             "COLL_NAME, META_COLL_ATTR_VALUE",
@@ -142,27 +154,21 @@ def main(rule_args, callback, rei):
     modify_basedoiminted = global_vars["*modify_basedoiminted"]
     package = global_vars["*package"]
 
-    datapackages = []
     zone = session_vars.get_map(rei)['client_user']['irods_zone']
 
     # Verify existence of a data package if one is specified
     if package != '' and len(list(genquery.Query(callback, "COLL_ID", f"COLL_NAME = '{package}'"))) <= 0:
         callback.writeLine("stdout", "Specified collection was not found.")
     else:
-        datapackages = datapackages_and_versions(zone, package, callback)
-
-    # If data packages were found, transform AVUs
-    if datapackages:
         if modify_prefix == 'True':
             try:
-                prefix_transformation(zone, callback)
+                prefix_transformation(zone, package, callback)
             except Exception as e:
                 callback.writeLine("stdout", "prefix_transformation: Error encountered while modifying prefix for existing publications - {}".format(e))
 
         if modify_basedoiminted == 'True':
+            datapackages = datapackages_and_versions(zone, package, callback)
             basedoiminted_correction(zone, datapackages, callback)
-    else:
-        callback.writeLine("stdout", "No data packages were found.")
 
 
 INPUT *modify_prefix=False, *modify_basedoiminted=True, *package=


### PR DESCRIPTION
This PR adds option to transform publications tool to run operations on a single collection (instead of the whole zone, as per default)