### PR TITLE
YDA-6803: fix provider/consumer detection ARB

### DIFF
--- a/tools/arb-update-resources.py
+++ b/tools/arb-update-resources.py
@@ -186,7 +186,7 @@ def call_rule_update_misc(session):
 def is_on_provider():
     with open('/etc/irods/server_config.json', 'r') as f:
         config = json.load(f)
-        return config["icat_host"] == get_hostname()
+        return "icat_host" in config and config["icat_host"] == get_hostname()
 
 
 def main():


### PR DESCRIPTION
The ARB script failed with an exception on some consumer environments because it assumed server configs always have an icat_host key. This fix ensures the script also works correctly if that is not the case.