### PR TITLE
Fix: improve (sub)category names' validation

### DIFF
--- a/unit-tests/test_util_yoda_names.py
+++ b/unit-tests/test_util_yoda_names.py
@@ -1,6 +1,6 @@
 """Unit tests for the yoda_names utils functions"""
 
-__copyright__ = 'Copyright (c) 2023-2024, Utrecht University'
+__copyright__ = 'Copyright (c) 2023-2026, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import sys
@@ -18,7 +18,10 @@ class UtilYodaNamesTest(TestCase):
         self.assertEqual(is_valid_category("foo"), True)
         self.assertEqual(is_valid_category("foo123"), True)
         self.assertEqual(is_valid_category("foo-bar"), True)
-        self.assertEqual(is_valid_category("foo_bar"), True)
+        self.assertEqual(is_valid_category("foo_bar"), False)
+        self.assertEqual(is_valid_category("Foo"), False)
+        self.assertEqual(is_valid_category("-foo"), False)
+        self.assertEqual(is_valid_category("foo-"), False)
 
     def test_is_valid_subcategory(self):
         self.assertEqual(is_valid_subcategory(""), False)
@@ -26,6 +29,10 @@ class UtilYodaNamesTest(TestCase):
         self.assertEqual(is_valid_subcategory("foo123"), True)
         self.assertEqual(is_valid_subcategory("foo-bar"), True)
         self.assertEqual(is_valid_subcategory("foo_bar"), True)
+        self.assertEqual(is_valid_subcategory("Foo Bar"), True)
+        self.assertEqual(is_valid_subcategory("Foo, Bar."), True)
+        self.assertEqual(is_valid_subcategory("Foo (Bar)"), True)
+        self.assertEqual(is_valid_subcategory("foo/bar"), False)
 
     def test_is_valid_groupname(self):
         self.assertEqual(is_valid_groupname(""), False)

--- a/util/yoda_names.py
+++ b/util/yoda_names.py
@@ -1,6 +1,6 @@
 """This class contains utility functions that process names of Yoda entities (e.g. category names, user names, etc.)"""
 
-__copyright__ = 'Copyright (c) 2019-2024, Utrecht University'
+__copyright__ = 'Copyright (c) 2019-2026, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import re
@@ -17,7 +17,11 @@ def is_valid_category(name: str) -> bool:
 
     :returns: boolean value that indicates whether this name is a valid category name
     """
-    return re.search(r"^[a-zA-Z0-9\-_]+$", name) is not None
+    return (
+        re.search(r"^[a-z0-9\-]+$", name) is not None
+        and not name.startswith("-")
+        and not name.endswith("-")
+    )
 
 
 def is_valid_subcategory(name: str) -> bool:
@@ -27,7 +31,9 @@ def is_valid_subcategory(name: str) -> bool:
 
     :returns: boolean value that indicates whether this name is a valid subcategory name
     """
-    return is_valid_category(name)
+    return (
+        re.search(r"^[A-Za-z0-9 ,._()-]+$", name) is not None
+    )
 
 
 def is_valid_groupname(name: str) -> bool:


### PR DESCRIPTION
Improved the functions for (sub)cat name validation and added unit tests.

The improvements are based on the design doc: https://utrechtuniversity.github.io/yoda/design/conventions/#category-names 

Also most of them are tested through portal's feature of adding group and cat/subcat,  to ensure the design doc correspond to portal's tech design