### PR TITLE
YDA-6916: add source path validation for archiving script

### DIFF
--- a/tools/archive_extract_data.sh
+++ b/tools/archive_extract_data.sh
@@ -67,6 +67,17 @@ validate_arguments() {
     
     # Mode-specific validations
     if [[ "$MODE" == "archive" ]]; then
+        # In archive mode, source collection must not end with '/'
+        if [[ "$SOURCE_PATH" != "/" && "$SOURCE_PATH" == */ ]]; then
+            cat <<EOF >&2
+ERROR: In archive mode, source path must not end with '/'
+  Provided: $SOURCE_PATH
+
+Please use source collection path without a trailing slash.
+EOF
+            errors=$((errors+1))
+        fi
+
         # For archive mode, check that target is not inside source
         local normalized_source="${SOURCE_PATH%/}"
         local normalized_target="${TARGET_PATH%/*}"  # Get parent path


### PR DESCRIPTION
Added a check for trailing slash. A trailing slash can result in issue in msiArchiveCreat.cc not be able to find the right source directory in archive mode.