### PR TITLE
yda-external-user-sync- Replace is_admin with is_rodsadmin in external users sync for SRAM

### DIFF
--- a/groups.py
+++ b/groups.py
@@ -1357,7 +1357,7 @@ def rule_external_users_sram_sync(ctx: rule.Context) -> None:
     :param ctx: Combined type of a ctx and rei struct
     """
     if not user.is_rodsadmin(ctx):
-        log.write(ctx, "SRAM sync requires admin privileges")
+        log.write(ctx, "SRAM sync requires rodsadmin privileges")
         return
 
     if not config.enable_sram:

--- a/groups.py
+++ b/groups.py
@@ -1356,7 +1356,7 @@ def rule_external_users_sram_sync(ctx: rule.Context) -> None:
 
     :param ctx: Combined type of a ctx and rei struct
     """
-    if not user.is_admin(ctx):
+    if not user.is_rodsadmin(ctx):
         log.write(ctx, "SRAM sync requires admin privileges")
         return
 


### PR DESCRIPTION
yda-external-user-sync- Replace is_admin with is_rodsadmin in external users sync for SRAM