### PR TITLE
Update user notifications default setting

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -16,7 +16,7 @@ __all__ = ['api_settings_load',
 # Allowed settings should be synchronised with policies and portal:
 # Policies: uuUserPolicyCanUserModify in yoda-ruleset/uuGroupPolicyChecks.r
 # Portal: settings in yoda-portal/user/user.py
-USER_SETTINGS = {"mail_notifications": {"default": "OFF", "values": ["OFF", "IMMEDIATE", "DAILY", "WEEKLY"]},
+USER_SETTINGS = {"mail_notifications": {"default": "IMMEDIATE", "values": ["OFF", "IMMEDIATE", "DAILY", "WEEKLY"]},
                  "group_manager_view": {"default": "TREE", "values": ["TREE", "LIST"]},
                  "number_of_items": {"default": "10", "values": ["10", "25", "50", "100"]},
                  "color_mode": {"default": "AUTO", "values": ["AUTO", "LIGHT", "DARK"]}}


### PR DESCRIPTION
Set user notification setting to IMMEDIATE by default. This change is based on feedback from users that it's easy to miss notifications if they don't receive an email about them. We want to provide a default setting that avoids that issue.