### PR TITLE
YDA-7004: refactor util.config

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,9 +59,9 @@ from vault                    import *
 from vault_deaccession        import *
 from epic                     import *
 
-# Import certain modules only when enabled.
-from .util.config import config
+from util.config import config
 
+# Import certain modules only when enabled.
 if config.enable_datarequest:
     from datarequest import *
 

--- a/policies.py
+++ b/policies.py
@@ -5,6 +5,7 @@ __copyright__ = 'Copyright (c) 2020-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import re
+from typing import Any
 
 import session_vars
 
@@ -733,5 +734,20 @@ def pep_api_sync_mounted_coll_pre(ctx: rule.Context,
     return policy.fail("Synchronizing mounted collections on the server is not allowed.")
 
 
+pep_api_authenticate_post_checked_config = False
+
+
+@policy.require()
+def pep_api_authenticate_post(ctx: rule.Context,
+                              *args: Any) -> policy.Succeed | policy.Fail:
+    global pep_api_authenticate_post_checked_config
+
+    if not pep_api_authenticate_post_checked_config:
+        configuration_errors = config.get_configuration_errors()
+        if len(configuration_errors) > 0:
+            log.write(ctx, "The ruleset configuration file has errors: " + str(configuration_errors))
+        pep_api_authenticate_post_checked_config = True
+
+    return policy.succeed()
 # }}}
 # }}}

--- a/unit-tests/test_util_config.py
+++ b/unit-tests/test_util_config.py
@@ -1,0 +1,197 @@
+"""Unit tests for the Config object and configuration file parsing"""
+
+__copyright__ = 'Copyright (c) 2026, Utrecht University'
+__license__   = 'GPLv3, see LICENSE'
+
+import sys
+from unittest import TestCase
+
+sys.path.append('../util')
+
+from config import Config
+
+
+def config_lines(text):
+    """Turn a config-file string into the (line number, line) list that
+    _load_config expects (the same shape _get_contents_config_file produces).
+
+    :param text: raw text of the configuration file
+
+    :returns:    list of <line number, line text> tuples of the configuration
+    """
+    return list(enumerate(text.splitlines(keepends=True)))
+
+
+class UtilConfigTest(TestCase):
+
+    def _get_config(self, *args, **kwargs):
+        config = Config(*args, **kwargs)
+        config._quiet_mode = True
+        return config
+
+    # --- Config object basics -------------------------------------------------
+
+    def test_defaults_are_populated(self):
+        config = self._get_config()
+        self.assertEqual(config.enable_sram, True)
+        self.assertEqual(config.environment, None)
+        self.assertEqual(config.resource_primary, [])
+        self.assertEqual(config.token_length, 0)
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_kwargs_override_defaults(self):
+        config = self._get_config(environment='development')
+        self.assertEqual(config.environment, 'development')
+        # Options that were not passed keep their default.
+        self.assertEqual(config.enable_sram, True)
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_access_unknown_option_raises(self):
+        config = self._get_config()
+        with self.assertRaises(AttributeError):
+            _ = config.does_not_exist
+
+    def test_set_unknown_option_is_ignored(self):
+        config = self._get_config()
+        config.does_not_exist = 'value'  # ignored (only prints a warning)
+        with self.assertRaises(AttributeError):
+            _ = config.does_not_exist
+
+    def test_set_known_option(self):
+        config = self._get_config()
+        config.environment = 'production'
+        self.assertEqual(config.environment, 'production')
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_freeze_blocks_changes(self):
+        config = self._get_config()
+        self.assertFalse(config.is_initialized())
+        config.freeze()
+        self.assertTrue(config.is_initialized())
+        config.environment = 'production'  # ignored once frozen
+        self.assertEqual(config.environment, None)
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    # --- _load_config: value parsing & type coercion --------------------------
+
+    def test_parse_string_value(self):
+        config = self._get_config()
+        config._load_config(config_lines("environment = 'production'\n"))
+        self.assertEqual(config.environment, 'production')
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_parse_empty_string_value_yields_none(self):
+        # "key =" (no quoted value) sets a string option to None.
+        config = self._get_config(default_yoda_schema='default-3')
+        config._load_config(config_lines("default_yoda_schema =\n"))
+        self.assertIsNone(config.default_yoda_schema)
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_parse_bool_true_and_false(self):
+        config = self._get_config()
+        config._load_config(config_lines("enable_sram = 'false'\nenable_tokens = 'true'\n"))
+        self.assertIs(config.enable_sram, False)
+        self.assertIs(config.enable_tokens, True)
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_parse_int_value(self):
+        config = self._get_config()
+        config._load_config(config_lines("token_length = '32'\n"))
+        self.assertEqual(config.token_length, 32)
+        self.assertIsInstance(config.token_length, int)
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_parse_list_value(self):
+        config = self._get_config()
+        config._load_config(config_lines("resource_primary = 'irodsResc1 irodsResc2 irodsResc3'\n"))
+        self.assertEqual(config.resource_primary, ['irodsResc1', 'irodsResc2', 'irodsResc3'])
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_whitespace_around_equals_is_tolerated(self):
+        config = self._get_config()
+        config._load_config(config_lines("environment   =    'production'\n"))
+        self.assertEqual(config.environment, 'production')
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_multiple_options_in_one_pass(self):
+        config = self._get_config()
+        config._load_config(config_lines(
+            "environment = 'production'\n"
+            "enable_sram = 'false'\n"
+            "token_length = '16'\n"
+            "resource_primary = 'resc1 resc2'\n"
+        ))
+        self.assertEqual(config.environment, 'production')
+        self.assertIs(config.enable_sram, False)
+        self.assertEqual(config.token_length, 16)
+        self.assertEqual(config.resource_primary, ['resc1', 'resc2'])
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_load_config_mutates_only_the_instance(self):
+        # Parsing must not leak into a second, independent Config instance.
+        config_a = self._get_config()
+        config_b = self._get_config()
+        config_a._load_config(config_lines("environment = 'production'\n"))
+        self.assertEqual(config_a.environment, 'production')
+        self.assertIsNone(config_b.environment)
+        self.assertEqual(len(config_a.get_configuration_errors()), 0)
+        self.assertEqual(len(config_b.get_configuration_errors()), 0)
+
+    # --- _load_config: skipping & ignoring ------------------------------------
+
+    def test_comments_and_blank_lines_are_skipped(self):
+        config = self._get_config()
+        config._load_config(config_lines(
+            "# this is a comment\n"
+            "\n"
+            "   \n"
+            "environment = 'production'\n"
+            "# enable_sram = 'false'\n"
+        ))
+        self.assertEqual(config.environment, 'production')
+        # The commented-out option keeps its default.
+        self.assertIs(config.enable_sram, True)
+        self.assertEqual(len(config.get_configuration_errors()), 0)
+
+    def test_unknown_option_error_detected(self):
+        config = self._get_config()
+        # Unknown keys parse fine (type falls back to str) but setattr drops them.
+        config._load_config(config_lines("not_a_real_option = 'whatever'\n"))
+        with self.assertRaises(AttributeError):
+            _ = config.not_a_real_option
+        self.assertEqual(len(config.get_configuration_errors()), 1)
+
+    # --- _load_config: error handling -----------------------------------------
+
+    def test_no_equals_sign_error_detected(self):
+        config = self._get_config()
+        config._load_config(config_lines("this line has no equals sign\n"))
+        self.assertEqual(len(config.get_configuration_errors()), 1)
+
+    def test_string_no_opening_quote_error_detected(self):
+        config = self._get_config()
+        config._load_config(config_lines("environment = development'\n"))
+        self.assertEqual(len(config.get_configuration_errors()), 1)
+
+    def test_string_no_trailing_quote_error_detected(self):
+        config = self._get_config()
+        config._load_config(config_lines("environment = 'development\n"))
+        self.assertEqual(len(config.get_configuration_errors()), 1)
+
+    def test_string_no_quotes_error_detected(self):
+        config = self._get_config()
+        config._load_config(config_lines("environment = development\n"))
+        self.assertEqual(len(config.get_configuration_errors()), 1)
+
+    def test_invalid_bool_value_error_detected(self):
+        config = self._get_config()
+        config._load_config(config_lines("enable_sram = 'yes'\n"))
+        self.assertEqual(len(config.get_configuration_errors()), 1)
+
+    def test_empty_value_for_list_option_detected(self):
+        config = self._get_config()
+        config._load_config(config_lines("resource_primary =\n"))
+        # Not a valid line, so default value is retained.
+        self.assertEqual(config.resource_primary, [])
+        # But an error is logged
+        self.assertEqual(len(config.get_configuration_errors()), 1)

--- a/unit-tests/unit_tests.py
+++ b/unit-tests/unit_tests.py
@@ -8,6 +8,7 @@ from test_metadata_utils import MetadataUtilsTest
 from test_policies import PoliciesTest
 from test_revisions import RevisionTest
 from test_schema_transformations import CorrectifyIsniTest, CorrectifyOrcidTest, CorrectifyResearcherIDTest, CorrectifyScopusTest, MergeGeoKeywordsTest, RenameRelatedDatapackageTest
+from test_util_config import UtilConfigTest
 from test_util_misc import UtilMiscTest
 from test_util_pathutil import UtilPathutilTest
 from test_util_schema_utils import SchemaUtilsTest
@@ -28,6 +29,7 @@ def suite():
     test_suite.addTest(makeSuite(PoliciesTest))
     test_suite.addTest(makeSuite(RevisionTest))
     test_suite.addTest(makeSuite(SchemaUtilsTest))
+    test_suite.addTest(makeSuite(UtilConfigTest))
     test_suite.addTest(makeSuite(UtilMiscTest))
     test_suite.addTest(makeSuite(UtilPathutilTest))
     test_suite.addTest(makeSuite(UtilYodaNamesTest))

--- a/util/config.py
+++ b/util/config.py
@@ -4,44 +4,214 @@ from __future__ import annotations
 __copyright__ = 'Copyright (c) 2019-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
-from typing import List
-
+import inspect
+import os
+import re
+from typing import Any, List, Tuple
 
 # Config class {{{
+
 
 class Config:
     """Stores configuration info, accessible through attributes (config.foo).
 
-    Valid options are determined at __init__ time.
+    Valid options are determined when the object is initialized
     Setting non-existent options raises an AttributeError.
     Accessing non-existent options raises an AttributeError as well.
 
-    Example:
-
-      config = Config(foo = 'stuff')
-      config.foo = 'other stuff'
-
+    Examples:
       x = config.foo
-      y = config.bar  # AttributeError
+      y = config.bar  # AttributeError if bar does not exist
     """
 
-    def __init__(self, **kwargs: int) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         """kwargs must contain all valid options and their default values."""
-        self._items  = kwargs
+        default_values = self._get_default_values()
+        self._items  = {**default_values, **kwargs}
         self._frozen = False
+        self._quiet_mode = False   # Meant for unit tests
+        self._loading_errors = []
+
+    def _get_default_values(self):
+        """Should return all valid configuration items and their default value."""
+        return {"environment": None,
+                "measure_coverage": False,
+                "default_yoda_schema": None,
+                "resource_primary": [],
+                "resource_trigger_pol": [],
+                "resource_repl_exempt": [],
+                "resource_replica": [],
+                "resource_research": None,
+                "resource_vault": None,
+                "notifications_enabled": False,
+                "notifications_sender_email": None,
+                "notifications_sender_name": None,
+                "notifications_reply_to": None,
+                "smtp_server": None,
+                "smtp_username": None,
+                "smtp_password": None,
+                "smtp_auth": True,
+                "smtp_starttls": True,
+                "datacite_rest_api_url": None,
+                "datacite_username": None,
+                "datacite_password": None,
+                "datacite_publisher": None,
+                "datacite_tls_verify": True,
+                "eus_api_fqdn": None,
+                "eus_api_port": None,
+                "eus_api_secret": None,
+                "eus_api_tls_verify": True,
+                "enable_deposit": False,
+                "enable_open_search": False,
+                "enable_inactivity_notification": False,
+                "enable_datarequest": False,
+                "enable_data_package_archive": False,
+                "data_package_archive_fqdn": None,
+                "data_package_archive_minimum": 0,
+                "data_package_archive_maximum": 0,
+                "data_package_archive_resource": None,
+                "enable_data_package_reference": False,
+                "enable_tokens": False,
+                "inactivity_cutoff_months": 3,
+                "token_database": None,
+                "token_database_password": None,
+                "token_length": 0,
+                "token_lifetime": 0,
+                "token_expiration_notification": 0,
+                "enable_async_checksum": False,
+                "async_checksum_delay_time": 0,
+                "async_replication_delay_time": 0,
+                "async_replication_max_rss": 1000000000,
+                "async_revision_delay_time": 0,
+                "async_revision_max_rss": 1000000000,
+                "yoda_portal_fqdn": None,
+                "epic_pid_enabled": False,
+                "epic_url": None,
+                "epic_handle_prefix": None,
+                "epic_key": None,
+                "epic_certificate": None,
+                "temporary_files": [],
+                "external_users_domain_filter": [],
+                "remote_anonymous_access": [],
+                "enable_sram": True,
+                "sram_rest_api_url": None,
+                "sram_api_key": None,
+                "sram_service_entity_id": None,
+                "sram_verbose_logging": False,
+                "sram_tls_verify": True,
+                "sram_co_default_label": None,
+                "sram_co_logo": None,
+                "sram_co_default_admins": [],
+                "sram_external_users_co": None,
+                "arb_enabled": False,
+                "arb_exempt_resources": [],
+                "arb_min_gb_free": 0,
+                "arb_min_percent_free": 5,
+                "text_file_extensions": [],
+                "pregenerated_data_dir": None,
+                "matomo_tracking_enabled": False,
+                "matomo_counter_enabled": False,
+                "matomo_server_fqdn": None,
+                "matomo_site_id": 1,
+                "vault_copy_backoff_time": 300,
+                "vault_copy_max_retries": 5,
+                "vault_copy_multithread_enabled": True,
+                "user_max_connections_enabled": False,
+                "user_max_connections_number": 4,
+                "enable_nfs_resource": False,
+                "deaccession_cooldown": 14}
+
+    def _get_config_filename(self) -> str:
+        return os.path.join(os.path.dirname(__file__), '../rules_uu.cfg')
+
+    def _get_contents_config_file(self) -> List[Tuple[int, str]]:
+        with open(self._get_config_filename()) as f:
+            contents = list(enumerate(f))
+        return contents
+
+    def _load_config(self, config_lines: List[Tuple[int, str]]) -> None:
+        for i, line in config_lines:
+            line = line.strip()
+            # Skip comments, whitespace lines.
+            if line.startswith('#') or len(line) == 0:
+                continue
+            # Interpret {k = 'v'} and {k =}
+            m = re.match(r"""^([\w_]+)\s*=\s*(?:'(.*)')?$""", line)
+            if not m:
+                error_message = 'Configuration syntax error at {} line {}'.format(self._get_config_filename(), i + 1)
+                # We do not throw an exception here, because that would cause the rule engine to fail
+                # completely with a generic error message (since config initialization is at
+                # compile time). Instead, we store the error message here, then have the policies
+                # log any error message once the session has been fully established.
+                self._loading_errors.append(error_message)
+                continue
+
+            # List-type values are separated by whitespace.
+            try:
+                typ = type(getattr(self, m.group(1)))
+            except AttributeError:
+                typ = str
+
+            if issubclass(typ, list):
+                if m.group(2) is None:
+                    error_message = 'Configuration syntax error at {} line {}'.format(self._get_config_filename(), i + 1)
+                    self._loading_errors.append(error_message)
+                    continue
+                else:
+                    setattr(self, m.group(1), m.group(2).split())
+            elif issubclass(typ, bool):
+                try:
+                    setattr(self, m.group(1), {'true': True, 'false': False}[m.group(2)])
+                except KeyError:
+                    error_message = 'Configuration syntax error at {} line {}'.format(self._get_config_filename(), i + 1)
+                    # We do not throw an exception here, because that would cause the rule engine to fail
+                    # completely with an obscure generic error message (since config initialization is at
+                    # compile time). Instead, we store the error message, then print warnings once the
+                    # session has been initialized.
+                    self._loading_errors.append(error_message)
+
+            elif issubclass(typ, int):
+                setattr(self, m.group(1), int(m.group(2)))
+            else:
+                setattr(self, *m.groups())
 
     def freeze(self) -> None:
         """Prevent further config changes via setattr."""
         self._frozen = True
 
+    def is_initialized(self):
+        return self._frozen
+
+    def initialize(self):
+        # Try to prevent (accidental) config changes.
+        if self.is_initialized():
+            # Don't log this to reduce log clutter.
+            return
+
+        if os.path.exists(self._get_config_filename()):
+            config_file_contents = self._get_contents_config_file()
+            self._load_config(config_file_contents)
+        else:
+            if not self._quiet_mode:
+                print("Configuration file not found. Initializing default configuration.")
+
+        self.freeze()
+
+    def get_configuration_errors(self) -> List[str]:
+        return self._loading_errors
+
     def __setattr__(self, k: str, v: int) -> None:
         if k.startswith('_'):
             return super().__setattr__(k, v)
         if self._frozen:
-            print('Ruleset configuration error: No config changes possible to \'{}\''.format(k))
+            if not self._quiet_mode:
+                print('Ruleset configuration error: No config changes possible to \'{}\''.format(k))
             return
         if k not in self._items:
-            print('Ruleset configuration error: No such config option: \'{}\''.format(k))
+            error_message = 'Ruleset configuration error: No such config option: \'{}\''.format(k)
+            self._loading_errors.append(error_message)
+            if not self._quiet_mode:
+                print(error_message)
             return
         # Set as config option.
         self._items[k] = v
@@ -49,6 +219,7 @@ class Config:
     def __getattr__(self, k: str) -> str | int | bool | List:
         if k.startswith('_'):
             return super().__getattr__(k)
+
         try:
             return self._items[k]
         except KeyError:
@@ -62,142 +233,12 @@ class Config:
     def __repr__(self) -> str:
         return 'Config()'
 
-    # def __repr__(self):
-    #     return 'Config(\n{})'.format(''.join('  {} = {},\n'.format(k,
-    #                 ('\n  '.join(repr(v).splitlines()) if isinstance(v, Config) else repr(v)))
-    #                     for k, v in self._items.items()))
-
 # }}}
 
 
-# Default config {{{
-
-# Note: Must name all valid config items.
-config = Config(environment=None,
-                measure_coverage=False,
-                default_yoda_schema=None,
-                resource_primary=[],
-                resource_trigger_pol=[],
-                resource_repl_exempt=[],
-                resource_replica=[],
-                resource_research=None,
-                resource_vault=None,
-                notifications_enabled=False,
-                notifications_sender_email=None,
-                notifications_sender_name=None,
-                notifications_reply_to=None,
-                smtp_server=None,
-                smtp_username=None,
-                smtp_password=None,
-                smtp_auth=True,
-                smtp_starttls=True,
-                datacite_rest_api_url=None,
-                datacite_username=None,
-                datacite_password=None,
-                datacite_publisher=None,
-                datacite_tls_verify=True,
-                eus_api_fqdn=None,
-                eus_api_port=None,
-                eus_api_secret=None,
-                eus_api_tls_verify=True,
-                enable_deposit=False,
-                enable_open_search=False,
-                enable_inactivity_notification=False,
-                enable_datarequest=False,
-                enable_data_package_archive=False,
-                data_package_archive_fqdn=None,
-                data_package_archive_minimum=0,
-                data_package_archive_maximum=0,
-                data_package_archive_resource=None,
-                enable_data_package_reference=False,
-                enable_tokens=False,
-                inactivity_cutoff_months=3,
-                token_database=None,
-                token_database_password=None,
-                token_length=0,
-                token_lifetime=0,
-                token_expiration_notification=0,
-                enable_async_checksum=False,
-                async_checksum_delay_time=0,
-                async_replication_delay_time=0,
-                async_replication_max_rss=1000000000,
-                async_revision_delay_time=0,
-                async_revision_max_rss=1000000000,
-                yoda_portal_fqdn=None,
-                epic_pid_enabled=False,
-                epic_url=None,
-                epic_handle_prefix=None,
-                epic_key=None,
-                epic_certificate=None,
-                temporary_files=[],
-                external_users_domain_filter=[],
-                remote_anonymous_access=[],
-                enable_sram=True,
-                sram_rest_api_url=None,
-                sram_api_key=None,
-                sram_service_entity_id=None,
-                sram_verbose_logging=False,
-                sram_tls_verify=True,
-                sram_co_default_label=None,
-                sram_co_logo=None,
-                sram_co_default_admins=[],
-                sram_external_users_co=None,
-                arb_enabled=False,
-                arb_exempt_resources=[],
-                arb_min_gb_free=0,
-                arb_min_percent_free=5,
-                text_file_extensions=[],
-                pregenerated_data_dir=None,
-                matomo_tracking_enabled=False,
-                matomo_counter_enabled=False,
-                matomo_server_fqdn=None,
-                matomo_site_id=1,
-                vault_copy_backoff_time=300,
-                vault_copy_max_retries=5,
-                vault_copy_multithread_enabled=True,
-                user_max_connections_enabled=False,
-                user_max_connections_number=4,
-                enable_nfs_resource=False,
-                deaccession_cooldown=14)
-
-# }}}
-
-# Optionally include a site-local config file to override the above.
-# (note: this is done only once per agent)
-try:
-    import os
-    import re
-    # Look for a config file in the root dir of this ruleset.
-    cfgpath = os.path.dirname(__file__) + '/../rules_uu.cfg'
-    with open(cfgpath) as f:
-        for i, line in enumerate(f):
-            line = line.strip()
-            # Skip comments, whitespace lines.
-            if line.startswith('#') or len(line) == 0:
-                continue
-            # Interpret {k = 'v'} and {k =}
-            m = re.match(r"""^([\w_]+)\s*=\s*(?:'(.*)')?$""", line)
-            if not m:
-                raise Exception('Configuration syntax error at {} line {}'.format(cfgpath, i + 1))
-
-            # List-type values are separated by whitespace.
-            try:
-                typ = type(getattr(config, m.group(1)))
-            except AttributeError:
-                typ = str
-
-            if issubclass(typ, list):
-                setattr(config, m.group(1), m.group(2).split())
-            elif issubclass(typ, bool):
-                setattr(config, m.group(1), {'true': True, 'false': False}[m.group(2)])
-            elif issubclass(typ, int):
-                setattr(config, m.group(1), int(m.group(2)))
-            else:
-                setattr(config, *m.groups())
-
-except OSError:
-    # Ignore, config file is optional.
-    pass
-
-# Try to prevent (accidental) config changes.
-config.freeze()
+config = Config()
+if any("yoda-ruleset/unit-tests/test_" in frame_info.filename for frame_info in inspect.stack()):
+    # If we are running in the context of unit tests, suppress any warning messages to
+    # reduce clutter in the test output.
+    config._quiet_mode = True
+config.initialize()


### PR DESCRIPTION
Refactor the configuration code to accomplish the following:
- Nearly all code has been moved to the Configuration object, so that it is testable.
- Added unit tests for the key functions
- Deferred any exceptions that occurred during parsing the configuration file until we are past the compilation stage and authentication PEPs. At that time, we have proper error logging, and we can tell the technical administrator what's going on, rather than failing in a way that only shows a generic rule engine error message.