### PR TITLE
YDA-7048: fix import issue after config refactor

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,8 +59,6 @@ from vault                    import *
 from vault_deaccession        import *
 from epic                     import *
 
-from util.config import config
-
 # Import certain modules only when enabled.
 if config.enable_datarequest:
     from datarequest import *


### PR DESCRIPTION
In YDA-7004, the config module was refactored. The change in __init__.py introduced an import ordering issue that only appeared when the data package archiving module was enabled (because of the order of transitive imports). This fix ensures that the code in vault_archive.py also imports the correct config variable .