### PR TITLE
YDA-7000: encode/escape paths before passing to rules

### DIFF
--- a/tools/admin/admin-copy-to-research.sh
+++ b/tools/admin/admin-copy-to-research.sh
@@ -2,8 +2,8 @@
 actor="$1"
 coll_origin="$2"
 coll_target="$3"
-retry_str="$4"
 receiver="$actor"
+retry_str="$5"
 
 irule -r irods_rule_engine_plugin-irods_rule_language-instance \
       -F /etc/irods/yoda-ruleset/tools/copy-to-research.r \

--- a/tools/prepare-vault-archive.r
+++ b/tools/prepare-vault-archive.r
@@ -8,7 +8,6 @@ prepareVaultArchive {
 
 	*status = "";
 	rule_vault_archive(*actor, *coll, *action, *status);
-	writeLine("stdout", "*actor archive *coll *action: *status");
 }
 
 input *actor="", *coll="", *action=""

--- a/vault.py
+++ b/vault.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 __copyright__ = 'Copyright (c) 2019-2026, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
+import base64
 import json
 import os
 import re
@@ -255,9 +256,11 @@ def schedule_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target: 
     :param retry_count:  Current retry attempt as int
     :param wait_seconds: Delay in seconds
     """
+    encoded_origin = base64.b64encode(coll_origin.encode()).decode()
+    encoded_target = base64.b64encode(coll_target.encode()).decode()
     ctx.delayExec(
-        f"<PLUSET>{wait_seconds}s</PLUSET>",
-        f"iiAdminVaultCopyToResearch('{coll_origin}', '{coll_target}', '{actor}', '{retry_count}')",
+        f"<INST_NAME>irods_rule_engine_plugin-irods_rule_language-instance</INST_NAME><PLUSET>{wait_seconds}s</PLUSET>",
+        f"iiAdminVaultCopyToResearch('{encoded_origin}', '{encoded_target}', '{actor}', '{retry_count}')",
         "")
 
 
@@ -267,38 +270,54 @@ def rule_vault_copy_to_research(ctx: rule.Context, coll_origin: str, coll_target
     If the copy operation fails, it will be retried up to a maximum number of times.
 
     :param ctx:         Combined type of a callback and rei struct
-    :param coll_origin: Origin data collection in vault space
-    :param coll_target: Target collection in research or deposit space
+    :param coll_origin: Base64-encoded origin data collection in vault space
+    :param coll_target: Base64-encoded target collection in research or deposit space
     :param actor:       User to notify of success/failure
     :param retry_str:   Current retry attempt as string
 
     :returns:           True if operation succeeded or entered retry logic, False if target already existed
     """
-    log.write(ctx, f"Starting vault copy: {coll_origin} -> {coll_target}, attempt #{retry_str}")
+    # Decode base64-encoded paths
+    try:
+        decoded_origin = base64.b64decode(coll_origin).decode('utf-8')
+        decoded_target = base64.b64decode(coll_target).decode('utf-8')
+    except Exception as e:
+        log.write(ctx, f"Failed to decode base64-encoded paths during copy-to-research: {str(e)}")
+        return
 
-    space, _, _, _ = pathutil.info(coll_target)
+    if not decoded_origin or not decoded_origin.startswith('/'):
+        log.write(ctx, f"Invalid origin path after decoding for copy-to-research: <{decoded_origin}>")
+        return
+
+    if not decoded_target or not decoded_target.startswith('/'):
+        log.write(ctx, f"Invalid target path after decoding for copy-to-research: <{decoded_target}>")
+        return
+
+    log.write(ctx, f"Starting vault copy: {decoded_origin} -> {decoded_target}, attempt #{retry_str}")
+
+    space, _, _, _ = pathutil.info(decoded_target)
 
     # Check target already existed during the retry process, to prevent double clicking
-    if space is pathutil.Space.RESEARCH and collection.exists(ctx, coll_target):
-        log.write(ctx, f"Target collection already exists: {coll_target}")
+    if space is pathutil.Space.RESEARCH and collection.exists(ctx, decoded_target):
+        log.write(ctx, f"Target collection already exists: {decoded_target}")
         return None
 
     # Execute copy operation through irsync cmd
-    success = copy_folder_to_research(ctx, coll_origin, coll_target)
+    success = copy_folder_to_research(ctx, decoded_origin, decoded_target)
 
     # Handle result
     if success:
         # Fix ACLs for data package copied to deposit.
         if space is pathutil.Space.DEPOSIT:
-            msi.set_acl(ctx, "recursive", "admin:own", actor, coll_target)
+            msi.set_acl(ctx, "recursive", "admin:own", actor, decoded_target)
 
-        _, _, _, datapackage_name = pathutil.info(coll_origin)
-        notifications.set(ctx, "system", actor, coll_target, f"Copying data package <{datapackage_name}>finished")
-        log.write(ctx, f"Copy successful: {coll_origin}")
+        _, _, _, datapackage_name = pathutil.info(decoded_origin)
+        notifications.set(ctx, "system", actor, decoded_target, f"Copying data package <{datapackage_name}>finished")
+        log.write(ctx, f"Copy successful: {decoded_origin}")
     else:
         # Copy failed and enter retry logic
         retry_count = int(retry_str)
-        handle_retry_operation(ctx, coll_origin, coll_target, actor, retry_count)
+        handle_retry_operation(ctx, decoded_origin, decoded_target, actor, retry_count)
 
 
 def copy_folder_to_research(ctx: rule.Context, coll: str, target: str) -> bool:

--- a/vault_archive.py
+++ b/vault_archive.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 __copyright__ = 'Copyright (c) 2023-2026, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
+import base64
 import json
 import time
 from typing import Dict, List
@@ -14,6 +15,7 @@ import irods_types
 import folder
 import groups
 import meta
+import misc
 import notifications
 import provenance
 import vault
@@ -73,8 +75,9 @@ def package_provenance_log(ctx: rule.Context, system_metadata: List) -> List:
 
 
 def package_archive_path(ctx: rule.Context, coll: str) -> str | None:
+    coll = misc.escape(coll)    # Escape single quotes
     for row in genquery.row_iterator("DATA_PATH",
-                                     "COLL_NAME = '{}' AND DATA_NAME = 'archive.tar'".format(coll),
+                                     f"COLL_NAME = '{coll}' AND DATA_NAME = 'archive.tar'",
                                      genquery.AS_LIST,
                                      ctx):
         return row[0]
@@ -314,8 +317,11 @@ def api_vault_archive(ctx: rule.Context, coll: str) -> api.Result:
     if not vault_archivable(ctx, coll) or vault_archival_status(ctx, coll):
         return "Invalid"
 
+    # Encode paths into base64
+    encoded_coll = base64.b64encode(coll.encode()).decode()
+
     try:
-        ctx.iiAdminVaultArchive(coll, constants.vault_archive_state.ARCHIVE.value)
+        ctx.iiAdminVaultArchive(encoded_coll, constants.vault_archive_state.ARCHIVE.value)
         return "Success"
     except Exception:
         return "Failure"
@@ -352,19 +358,35 @@ def api_vault_extract(ctx: rule.Context, coll: str) -> api.Result:
     if vault_archival_status(ctx, coll) != constants.vault_archive_state.ARCHIVED.value:
         return "Invalid"
 
+    # Encode paths into base64
+    encoded_coll = base64.b64encode(coll.encode()).decode()
+
     try:
-        ctx.iiAdminVaultArchive(coll, constants.vault_archive_state.EXTRACT.value)
+        ctx.iiAdminVaultArchive(encoded_coll, constants.vault_archive_state.EXTRACT.value)
         return "Success"
     except Exception:
         return "Failure"
 
 
-@rule.make(inputs=[0, 1, 2], outputs=[3])
-def rule_vault_archive(ctx: rule.Context, actor: str, coll: str, action: str) -> str:
+@rule.make(inputs=[0, 1, 2, 3], outputs=[3])
+def rule_vault_archive(ctx: rule.Context, actor: str, coll: str, action: str, status: str) -> str:
+    # Decode base64-encoded paths
+    try:
+        decoded_coll = base64.b64decode(coll).decode('utf-8')
+    except Exception as e:
+        log.write(ctx, f"Failed to decode base64-encoded path '{coll}' for archive: {str(e)}")
+        return "Failure"
+
+    if not decoded_coll or not decoded_coll.startswith('/'):
+        log.write(ctx, f"Invalid path after decoding for archive: <{decoded_coll}>")
+        return "Failure"
+
+    log.write(ctx, f"vault_archive: {actor} {action} '{decoded_coll}' (status: {status})")
+
     if action == "archive":
-        return vault_archive(ctx, actor, coll)
+        return vault_archive(ctx, actor, decoded_coll)
     elif action == "extract":
-        return vault_unarchive(ctx, actor, coll)
+        return vault_unarchive(ctx, actor, decoded_coll)
     else:
         return "Failure"
 

--- a/vault_deaccession.py
+++ b/vault_deaccession.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 __copyright__ = 'Copyright (c) 2026, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
+import base64
 import json
 from datetime import date, datetime
 from typing import List
@@ -144,7 +145,11 @@ def api_vault_request_deaccession(ctx: rule.Context, coll: str, reason: str) -> 
 
     if ret[0] == '':
         log.write(ctx, 'api_vault_request_deaccession: iiAdminVaultDeaccession')
-        ctx.iiAdminVaultDeaccession(coll, new_status.value)
+
+        # Encode paths into base64
+        encoded_coll = base64.b64encode(coll.encode()).decode()
+
+        ctx.iiAdminVaultDeaccession(encoded_coll, new_status.value)
         return 'Success'
     else:
         return api.Error(ret[0], ret[1])
@@ -168,7 +173,11 @@ def api_vault_cancel_deaccession(ctx: rule.Context, coll: str) -> api.Result:
 
     if ret[0] == '':
         log.write(ctx, 'api_vault_cancel_deaccession: iiAdminVaultDeaccession')
-        ctx.iiAdminVaultDeaccession(coll, new_status.value)
+
+        # Encode paths into base64
+        encoded_coll = base64.b64encode(coll.encode()).decode()
+
+        ctx.iiAdminVaultDeaccession(encoded_coll, new_status.value)
         return 'Success'
     else:
         return api.Error(ret[0], ret[1])
@@ -192,7 +201,11 @@ def api_vault_approve_deaccession(ctx: rule.Context, coll: str) -> api.Result:
 
     if ret[0] == '':
         log.write(ctx, 'api_vault_approve_deaccession: iiAdminVaultDeaccession')
-        ctx.iiAdminVaultDeaccession(coll, new_status.value)
+
+        # Encode paths into base64
+        encoded_coll = base64.b64encode(coll.encode()).decode()
+
+        ctx.iiAdminVaultDeaccession(encoded_coll, new_status.value)
         return 'Success'
     else:
         return api.Error(ret[0], ret[1])
@@ -213,7 +226,11 @@ def vault_complete_deaccession(ctx: rule.Context, coll: str) -> None:
 
     if ret[0] == '':
         log.write(ctx, 'api_vault_approve_deaccession: iiAdminVaultDeaccession')
-        ctx.iiAdminVaultDeaccession(coll, new_status.value)
+
+        # Encode paths into base64
+        encoded_coll = base64.b64encode(coll.encode()).decode()
+
+        ctx.iiAdminVaultDeaccession(encoded_coll, new_status.value)
     else:
         log.write(ctx, f"api_vault_approve_deaccession: Failed to complete deaccession on package '{coll}'")
 # }}}
@@ -445,7 +462,18 @@ def rule_process_deaccession_status_transitions(ctx: rule.Context, actor: str, c
     :param coll:             Vault package to be changed of status in deaccession cycle
     :param new_status:       New deaccession status
     """
-    process_deaccession_status_transition(ctx, actor, coll, new_status)
+    # Decode base64-encoded paths
+    try:
+        decoded_coll = base64.b64decode(coll).decode('utf-8')
+    except Exception as e:
+        log.write(ctx, f"Failed to decode base64-encoded path '{coll}' during deaccession: {str(e)}")
+        return
+
+    if not decoded_coll or not decoded_coll.startswith('/'):
+        log.write(ctx, f"Invalid path after decoding during deaccession: <{decoded_coll}>")
+        return
+
+    process_deaccession_status_transition(ctx, actor, decoded_coll, new_status)
 # }}}
 
 


### PR DESCRIPTION
This PR encodes paths before passing them to rules for copy-to-research. This solves issues with single quotes and spaces in paths.