### PR TITLE
YDA-7087: improve group manager performance

### DIFF
--- a/groups.py
+++ b/groups.py
@@ -352,6 +352,9 @@ def internal_api_group_data(ctx: rule.Context) -> Dict:
     managed_prefixes = ("priv-", "deposit-", "research-", "grp-", "datamanager-", "datarequests-", "intake-")
     groups = list(filter(lambda group: group['name'].startswith(managed_prefixes), groups))
 
+    # Prepare dictionary for quick lookup of category/environment-level schemas
+    schema_lookup_dict = schema.get_schema_category_lookup_dict(ctx)
+
     # Sort groups on name.
     groups = sorted(groups, key=lambda d: d['name'])
 
@@ -396,9 +399,9 @@ def internal_api_group_data(ctx: rule.Context) -> Dict:
         group_hierarchy[group['category']].setdefault(group['subcategory'], OrderedDict())
 
         # Check whether schema_id is present on group level.
-        # If not, collect it from the corresponding category
+        # If not, use the environment or category default
         if "schema_id" not in group:
-            group["schema_id"] = schema.get_schema_collection(ctx, user.zone(ctx), group['name'])
+            group["schema_id"] = schema_lookup_dict[group.get('category', "__nocategory")]
 
         coll_name = "/{}/home/{}".format(user.zone(ctx), group['name'])
 

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -364,6 +364,32 @@ def _test_schema_active_schema_vault_without_research(ctx):
     return result
 
 
+def _test_get_schema_category_lookup_dict(ctx: rule.Context) -> List[str]:
+    result: List[str] = []
+
+    dict1 = schema.get_schema_category_lookup_dict(ctx)
+
+    if dict1["test-automation"] != "default-3":
+        result.append("Fail env default / existing category")
+    if dict1["nonexistentcategory"] != "default-3":
+        result.append("Fail env default / nonexistent category")
+
+    schema_collection = "/tempZone/yoda/schemas/test-automation"
+    schema_object = f"{schema_collection}/metadata.json"
+    collection.create(ctx, schema_collection)
+    data_object.write(ctx, schema_object, "test")
+    dict2 = schema.get_schema_category_lookup_dict(ctx)
+
+    if dict2["test-automation"] != "test-automation":
+        result.append("Fail cat default / existing category")
+    if dict2["nonexistentcategory"] != "default-3":
+        result.append("Fail cat default / nonexistent category")
+
+    collection.remove(ctx, schema_collection)
+
+    return result
+
+
 def _test_get_latest_vault_metadata_path_empty(ctx):
     tmp_collection = _create_tmp_collection(ctx)
     latest_file = meta.get_latest_vault_metadata_path(ctx, tmp_collection)
@@ -781,6 +807,9 @@ basic_integration_tests = [
     {"name":  "schema.get_active_schema_path.vault-without-research",
      "test": lambda ctx: _test_schema_active_schema_vault_without_research(ctx),
      "check": lambda x: x == "/tempZone/yoda/schemas/default-3/metadata.json"},
+    {"name":  "schema.get_schema_category_lookup_dict",
+     "test": lambda ctx: _test_get_schema_category_lookup_dict(ctx),
+     "check": lambda x: x == []},
     # Vault metadata schema report: only check return value type, not contents
     {"name": "schema_transformation.batch_vault_metadata_schema_report",
      "test": lambda ctx: ctx.rule_batch_vault_metadata_schema_report(""),

--- a/schema.py
+++ b/schema.py
@@ -5,6 +5,7 @@ __copyright__ = 'Copyright (c) 2018-2025, Utrecht University'
 __license__   = 'GPLv3, see LICENSE'
 
 import re
+from collections import defaultdict
 from typing import Dict, Tuple
 
 import genquery
@@ -42,6 +43,41 @@ def api_schema_get_schemas(ctx: rule.Context) -> api.Result:
 
     return {'schemas': schemas,
             'schema_default': schema_default}
+
+
+def get_schema_category_lookup_dict(ctx: rule.Context) -> defaultdict:
+    """Returns a defaultdict that can be used to efficiently
+       look up category- and environment-level metadata schemas
+       of categories.
+
+    :param ctx:        Combined type of a callback and rei struct
+
+    :returns: defaultdict, where the default is the environment-level
+              default metadata schema, and the keys/values are categories
+              that have their own metadata schema. It will also return
+              the environment-level default metadata schema for nonexistent
+              categories.
+    """
+    # Function-level import to work around import dependency cycle
+    # without major refactoring or code duplication.
+    from groups import get_categories
+
+    result = defaultdict(lambda: config.default_yoda_schema)
+    categories = set(get_categories(ctx))
+    schema_path = '/' + user.zone(ctx) + '/yoda/schemas'
+
+    schema_collections = genquery.row_iterator(
+        "COLL_NAME",
+        f"DATA_NAME like 'metadata.json' AND COLL_NAME LIKE '{schema_path}/%'",
+        genquery.AS_LIST, ctx
+    )
+
+    for schema_collection in schema_collections:
+        name = schema_collection[0].split("/")[-1]
+        if name in categories:
+            result[name] = name
+
+    return result
 
 
 def get_schema_collection(ctx: rule.Context, rods_zone: str, group_name: str) -> str:


### PR DESCRIPTION
Improve group manager performance for environments that have a significant number of groups without a group-level metadata schema.

Read information about configured category-level and environment-level metadata schemas in a dictionary, and then use this dictionary to perform lookups, rather than looking up this information repeatedly in the iCAT database for every group without a group-level schema.