### PR TITLE
YDA-7169: fix publication related resource

### DIFF
--- a/templates/landingpage.html.j2
+++ b/templates/landingpage.html.j2
@@ -566,7 +566,9 @@
                             </div>
                         </div>
 
-                        {% if pack.Persistent_Identifier is defined %}
+                        {% if pack.Persistent_Identifier is defined and
+			      pack.Persistent_Identifier.Identifier_Scheme is defined and
+			      pack.Persistent_Identifier.Identifier is defined %}
                         <div class="row">
                             <div class="col-sm-3">
                                 <label class="indented">Persistent Identifier</label>


### PR DESCRIPTION
Fix issue where publication flow failed on data packages with a related resource that had an identifier type but not identifier.